### PR TITLE
Initial configure options flow

### DIFF
--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -1,14 +1,51 @@
+"""Config flow handler."""
+
 import voluptuous as vol
-from homeassistant import config_entries
+
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.core import callback
 from homeassistant.helpers import selector
+
 from .const import DOMAIN
 
-class ViewAssistConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+BASE_SCHEMA = {
+    vol.Required("name"): str,
+    vol.Required("mic_device"): selector.EntitySelector(
+        selector.EntitySelectorConfig(domain=["sensor", "assist_satellite"])
+    ),
+    vol.Required("mediaplayer_device"): selector.EntitySelector(
+        selector.EntitySelectorConfig(domain="media_player")
+    ),
+    vol.Required("musicplayer_device"): selector.EntitySelector(
+        selector.EntitySelectorConfig(domain="media_player")
+    ),
+}
+
+DISPLAY_SCHEMA = {
+    vol.Required("display_device"): selector.EntitySelector(
+        selector.EntitySelectorConfig(domain="sensor")
+    ),
+    vol.Required("browser_id"): str,
+}
+
+
+class ViewAssistConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for View Assist."""
 
     VERSION = 1
 
-    def __init__(self):
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler.
+
+        Remove this method and the ExampleOptionsFlowHandler class
+        if you do not want any options for your integration.
+        """
+        return ViewAssistOptionsFlowHandler(config_entry)
+
+    def __init__(self) -> None:
+        """Initialise."""
         self.type = None
 
     async def async_step_user(self, user_input=None):
@@ -20,13 +57,20 @@ class ViewAssistConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Show the initial form to select the type with descriptive text
         return self.async_show_form(
             step_id="user",
+            last_step=False,
             data_schema=vol.Schema(
                 {
                     vol.Required("type", default="view_audio"): selector.SelectSelector(
                         selector.SelectSelectorConfig(
                             options=[
-                                {"value": "view_audio", "label": "View Assist device with display"},
-                                {"value": "audio_only", "label": "View Assist device with no display"},
+                                {
+                                    "value": "view_audio",
+                                    "label": "View Assist device with display",
+                                },
+                                {
+                                    "value": "audio_only",
+                                    "label": "View Assist device with no display",
+                                },
                             ],
                             mode="dropdown",
                         )
@@ -40,43 +84,128 @@ class ViewAssistConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             # Include the type in the data to save in the config entry
             user_input["type"] = self.type
-            return self.async_create_entry(title=user_input.get("name", "View Assist"), data=user_input)
+            return self.async_create_entry(
+                title=user_input.get("name", "View Assist"), data=user_input
+            )
 
         # Define the schema based on the selected type
         if self.type == "view_audio":
-            data_schema = vol.Schema(
-                {
-                    vol.Required("name"): str,
-                    vol.Required("mic_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain=["sensor", "assist_satellite"])
-                    ),
-                    vol.Required("mediaplayer_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="media_player")
-                    ),
-                    vol.Required("musicplayer_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="media_player")
-                    ),
-                    vol.Required("display_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="sensor")
-                    ),
-                    vol.Required("browser_id"): str,
-                }
-            )
+            data_schema = vol.Schema({**BASE_SCHEMA, **DISPLAY_SCHEMA})
         else:  # audio_only
-            data_schema = vol.Schema(
-                {
-                    vol.Required("name"): str,
-                    vol.Required("mic_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain=["sensor", "assist_satellite"])
-                    ),
-                    vol.Required("mediaplayer_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="media_player")
-                    ),
-                    vol.Required("musicplayer_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="media_player")
-                    ),
-                }
-            )
+            data_schema = vol.Schema(BASE_SCHEMA)
 
         # Show the form for the selected type
         return self.async_show_form(step_id="options", data_schema=data_schema)
+
+
+class ViewAssistOptionsFlowHandler(OptionsFlow):
+    """Handles the options flow.
+
+    Here we use an initial menu to select different options forms,
+    and show how to use api data to populate a selector.
+    """
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+        self.options = dict(config_entry.options)
+        self.type = self.config_entry.data["type"]
+
+    async def async_step_init(self, user_input=None):
+        """Handle options flow."""
+
+        # Display an options menu if display device
+        # Display reconfigure form if audio onlu
+
+        # Also need to be in strings.json and translation files.
+
+        if self.type == "view_audio":
+            return self.async_show_menu(
+                step_id="init",
+                menu_options=["main_config", "display_options"],
+            )
+
+        return await self.async_step_main_config()
+
+    async def async_step_main_config(self, user_input=None):
+        """Handle main config flow."""
+
+        if user_input is not None:
+            # This is just updating the core config so update config_entry.data
+            user_input["type"] = self.type
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, data=user_input
+            )
+            return self.async_create_entry(data=None)
+        # Define the schema based on the selected type
+        BASE_OPTIONS = {
+            vol.Required("name", default=self.config_entry.data["name"]): str,
+            vol.Required(
+                "mic_device", default=self.config_entry.data["mic_device"]
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=["sensor", "assist_satellite"])
+            ),
+            vol.Required(
+                "mediaplayer_device",
+                default=self.config_entry.data["mediaplayer_device"],
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="media_player")
+            ),
+            vol.Required(
+                "musicplayer_device",
+                default=self.config_entry.data["musicplayer_device"],
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="media_player")
+            ),
+        }
+
+        if self.type == "view_audio":
+            data_schema = vol.Schema(
+                {
+                    **BASE_OPTIONS,
+                    vol.Required(
+                        "display_device",
+                        default=self.config_entry.data["display_device"],
+                    ): selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="sensor")
+                    ),
+                    vol.Required(
+                        "browser_id", default=self.config_entry.data["browser_id"]
+                    ): str,
+                }
+            )
+        else:  # audio_only
+            data_schema = vol.Schema(BASE_OPTIONS)
+
+        # Show the form for the selected type
+        return self.async_show_form(step_id="main_config", data_schema=data_schema)
+
+    async def async_step_display_options(self, user_input=None):
+        """Handle display options flow."""
+        if user_input is not None:
+            # This is just updating the core config so update config_entry.data
+            return self.async_create_entry(data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Optional(
+                    "display_op1",
+                    default=self.config_entry.options.get("display_op1", "abc"),
+                ): str,
+                vol.Optional(
+                    "display_op2",
+                    default=self.config_entry.options.get("display_op2", "def"),
+                ): str,
+                vol.Optional(
+                    "display_op3",
+                    default=self.config_entry.options.get("display_op3", "ghi"),
+                ): str,
+                vol.Optional(
+                    "display_op4",
+                    default=self.config_entry.options.get("display_op4", "klm"),
+                ): str,
+            }
+        )
+
+        # Show the form for the selected type
+        return self.async_show_form(step_id="display_options", data_schema=data_schema)

--- a/custom_components/view_assist/translations/en.json
+++ b/custom_components/view_assist/translations/en.json
@@ -1,0 +1,63 @@
+{
+  "config": {
+    "title": "Advanced Config Flow Example",
+    "abort": {
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Reconfiguration successful",
+      "already_in_progress": "A setup is already in progress for this integration"
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "invalid_settings": "Invalid settings",
+      "unknown": "Unexpected error"
+    },
+    "step": {
+      "init": {
+        "title": "Configure a View Assist device",
+        "data": {
+          "name": "name",
+          "mic_device": "Microphone device",
+          "mediaplayer_device": "Media player device",
+          "musicplayer_device": "Music player device",
+          "display_device": "Display Device",
+          "browser_id": "Browser Id"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Reconfigure a View Assist device",
+        "description": "Select which options to amend.",
+        "menu_options": {
+          "main_config": "Main Configuration",
+          "display_options": "Display Options"
+        }
+      },
+      "main_config": {
+        "title": "Main Config",
+        "description": "Option Set 1",
+        "data": {
+          "name": "name",
+          "mic_device": "Microphone device",
+          "mediaplayer_device": "Media player device",
+          "musicplayer_device": "Music player device",
+          "display_device": "Display Device",
+          "browser_id": "Browser Id"
+        }
+      },
+      "display_options": {
+        "title": "Display Options",
+        "description": "Option Set 2",
+        "data": {
+          "option1": "Option 1",
+          "option2": "Option 2",
+          "option3": "Option 3",
+          "option4": "Option 4"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
So, not done the full display options but what you will see is:

1. When creating a new instance, it will be as you already had it with diff options for display/audio only devices.
2. When selecting configure on a display device, you will get a menu to amend original config or options.
3. When selecting configure audio only device, you will go stright to the original config option screen.

Done a little code tidy up for you to make simpler to read also.

Happy to do more work on it for you but think from what you had already done, you should be good to move this bit forward