### PR TITLE
Navigate service

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -1,13 +1,21 @@
+import asyncio
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_DEVICE, CONF_PATH, Platform
 from homeassistant.core import (
+    HassJob,
     HomeAssistant,
     ServiceCall,
     ServiceResponse,
     SupportsResponse,
+    callback,
 )
+import voluptuous as vol
+from homeassistant.helpers.event import async_call_later, partial
+from homeassistant.util import timedelta
 from .const import DOMAIN
-#import homeassistant.helpers.entity_registry as er
+from homeassistant.helpers.selector import selector
+
+# import homeassistant.helpers.entity_registry as er
 from homeassistant.helpers import entity_registry as er
 
 import logging
@@ -16,52 +24,63 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
+NAVIGATE_SERVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE): selector(
+            {"entity": {"filter": {"integration": DOMAIN}}}
+        ),
+        vol.Required(CONF_PATH): str,
+    }
+)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up View Assist from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     # Request platform setup
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-##################
-# Get Target Satellite
-# Used to determine which VA satellite is being used based on its microphone device
-#
-# Sample usage
-# action: view_assist.get_target_satellite
-# data:
-#   device_id: 4385828338e48103f63c9f91756321df
-
+    ##################
+    # Get Target Satellite
+    # Used to determine which VA satellite is being used based on its microphone device
+    #
+    # Sample usage
+    # action: view_assist.get_target_satellite
+    # data:
+    #   device_id: 4385828338e48103f63c9f91756321df
 
     async def handle_get_target_satellite(call: ServiceCall) -> ServiceResponse:
-            """Handle a get target satellite lookup call."""
-            device_id = call.data.get("device_id")
-            entity_registry = er.async_get(hass)
+        """Handle a get target satellite lookup call."""
+        device_id = call.data.get("device_id")
+        entity_registry = er.async_get(hass)
 
-            entities = []
+        entities = []
 
-            entry_ids = [entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN)]
+        entry_ids = [
+            entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN)
+        ]
 
-            for entry_id in entry_ids:
-                integration_entities=er.async_entries_for_config_entry(entity_registry, entry_id)
-                entity_ids = [entity.entity_id for entity in integration_entities]
-                entities.extend(entity_ids)
+        for entry_id in entry_ids:
+            integration_entities = er.async_entries_for_config_entry(
+                entity_registry, entry_id
+            )
+            entity_ids = [entity.entity_id for entity in integration_entities]
+            entities.extend(entity_ids)
 
-   
-            # Fetch the 'mic_device' attribute for each entity
-            # compare the device_id of mic_device to the value passed in to the service
-            # return the match for the satellite that contains that mic_device
-            target_satellite_devices = []
-            for entity_id in entities:
-                if state := hass.states.get(entity_id):
-                    if mic_entity_id := state.attributes.get("mic_device"):
-                        if mic_entity := entity_registry.async_get(mic_entity_id):
-                            if mic_entity.device_id == device_id:
-                                target_satellite_devices.append(entity_id)
+        # Fetch the 'mic_device' attribute for each entity
+        # compare the device_id of mic_device to the value passed in to the service
+        # return the match for the satellite that contains that mic_device
+        target_satellite_devices = []
+        for entity_id in entities:
+            if state := hass.states.get(entity_id):
+                if mic_entity_id := state.attributes.get("mic_device"):
+                    if mic_entity := entity_registry.async_get(mic_entity_id):
+                        if mic_entity.device_id == device_id:
+                            target_satellite_devices.append(entity_id)
 
-
-            # Return the list of target_satellite_devices
-            # This should match only one VA device
-            return {"target_satellite": target_satellite_devices}
+        # Return the list of target_satellite_devices
+        # This should match only one VA device
+        return {"target_satellite": target_satellite_devices}
 
     hass.services.async_register(
         DOMAIN,
@@ -69,48 +88,74 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         handle_get_target_satellite,
         supports_response=SupportsResponse.ONLY,
     )
-#
-#########
 
+    #########
 
-#########
-# Handle Navigation
-# Used to determine how to change the view on the VA device
-#
-# action: view_assist.navigate
-# data:
-#   target_display_device: sensor.viewassist_office_browser_path
-#   target_display_type: browsermod
-#   path: /dashboard-viewassist/weather
-#
+    #########
+    # Handle Navigation
+    # Used to determine how to change the view on the VA device
+    #
+    # action: view_assist.navigate
+    # data:
+    #   target_display_device: sensor.viewassist_office_browser_path
+    #   target_display_type: browsermod
+    #   path: /dashboard-viewassist/weather
+    #
     async def handle_navigate(call: ServiceCall):
-            """Handle a navigate to view call."""
-            target_display_device = call.data.get('target_display_device')
-            target_display_type = call.data.get('target_display_type')
-            path = call.data.get('path')
+        """Handle a navigate to view call."""
+        va_entity_id = call.data.get("device")
+        path = call.data.get("path")
 
-            if not target_display_device or not target_display_type or not path:
-                # Figure out how to write an error to the log
-                _LOGGER.info('Received data', call.data)
-                return
-            
-            if target_display_type == "browsermod" :
-                await hass.services.async_call('browser_mod', 'navigate', {'entity_id': target_display_device, 'path': path})
+        # get config entry from entity id to allow access to browser_id parameter
+        entity_registry = er.async_get(hass)
+        if entity := entity_registry.async_get(va_entity_id):
+            entity_config_entry = hass.config_entries.async_get_entry(
+                entity.config_entry_id
+            )
+            browser_id = entity_config_entry.data.get("browser_id")
+
+            if browser_id:
+                await browser_navigate(browser_id, path, "/view_assist/clock")
 
     hass.services.async_register(
-        DOMAIN,
-        "navigate",
-        handle_navigate
+        DOMAIN, "navigate", handle_navigate, schema=NAVIGATE_SERVICE_SCHEMA
     )
 
-#
-########
+    async def browser_navigate(
+        browser_id: str,
+        path: str,
+        revert_path: str | None = None,
+        timeout: int = 10,
+    ):
+        """Navigate browser to defined view.
 
+        Optionally revert to another view after timeout.
+        """
+        _LOGGER.debug("Navigating: browser_id: %s, path: %s", browser_id, path)
+        await hass.services.async_call(
+            "browser_mod",
+            "navigate",
+            {"browser_id": browser_id, "path": path},
+        )
+
+        if revert_path and timeout:
+            _LOGGER.debug("Adding revert to %s in %ss", revert_path, timeout)
+            hass.loop.call_later(
+                10,
+                partial(
+                    hass.create_task,
+                    browser_navigate(browser_id, revert_path),
+                    f"Revert browser {browser_id}",
+                ),
+            )
 
     return True
-    
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    if unloaded := await hass.config_entries.async_forward_entry_unload(entry, PLATFORMS):
+    if unloaded := await hass.config_entries.async_forward_entry_unload(
+        entry, PLATFORMS
+    ):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unloaded

--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -1,14 +1,51 @@
+"""Config flow handler."""
+
 import voluptuous as vol
-from homeassistant import config_entries
+
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.core import callback
 from homeassistant.helpers import selector
+
 from .const import DOMAIN
 
-class ViewAssistConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+BASE_SCHEMA = {
+    vol.Required("name"): str,
+    vol.Required("mic_device"): selector.EntitySelector(
+        selector.EntitySelectorConfig(domain=["sensor", "assist_satellite"])
+    ),
+    vol.Required("mediaplayer_device"): selector.EntitySelector(
+        selector.EntitySelectorConfig(domain="media_player")
+    ),
+    vol.Required("musicplayer_device"): selector.EntitySelector(
+        selector.EntitySelectorConfig(domain="media_player")
+    ),
+}
+
+DISPLAY_SCHEMA = {
+    vol.Required("display_device"): selector.EntitySelector(
+        selector.EntitySelectorConfig(domain="sensor")
+    ),
+    vol.Required("browser_id"): str,
+}
+
+
+class ViewAssistConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for View Assist."""
 
     VERSION = 1
 
-    def __init__(self):
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler.
+
+        Remove this method and the ExampleOptionsFlowHandler class
+        if you do not want any options for your integration.
+        """
+        return ViewAssistOptionsFlowHandler(config_entry)
+
+    def __init__(self) -> None:
+        """Initialise."""
         self.type = None
 
     async def async_step_user(self, user_input=None):
@@ -20,13 +57,20 @@ class ViewAssistConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Show the initial form to select the type with descriptive text
         return self.async_show_form(
             step_id="user",
+            last_step=False,
             data_schema=vol.Schema(
                 {
                     vol.Required("type", default="view_audio"): selector.SelectSelector(
                         selector.SelectSelectorConfig(
                             options=[
-                                {"value": "view_audio", "label": "View Assist device with display"},
-                                {"value": "audio_only", "label": "View Assist device with no display"},
+                                {
+                                    "value": "view_audio",
+                                    "label": "View Assist device with display",
+                                },
+                                {
+                                    "value": "audio_only",
+                                    "label": "View Assist device with no display",
+                                },
                             ],
                             mode="dropdown",
                         )
@@ -40,43 +84,128 @@ class ViewAssistConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             # Include the type in the data to save in the config entry
             user_input["type"] = self.type
-            return self.async_create_entry(title=user_input.get("name", "View Assist"), data=user_input)
+            return self.async_create_entry(
+                title=user_input.get("name", "View Assist"), data=user_input
+            )
 
         # Define the schema based on the selected type
         if self.type == "view_audio":
-            data_schema = vol.Schema(
-                {
-                    vol.Required("name"): str,
-                    vol.Required("mic_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain=["sensor", "assist_satellite"])
-                    ),
-                    vol.Required("mediaplayer_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="media_player")
-                    ),
-                    vol.Required("musicplayer_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="media_player")
-                    ),
-                    vol.Required("display_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="sensor")
-                    ),
-                    vol.Required("browser_id"): str,
-                }
-            )
+            data_schema = vol.Schema({**BASE_SCHEMA, **DISPLAY_SCHEMA})
         else:  # audio_only
-            data_schema = vol.Schema(
-                {
-                    vol.Required("name"): str,
-                    vol.Required("mic_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain=["sensor", "assist_satellite"])
-                    ),
-                    vol.Required("mediaplayer_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="media_player")
-                    ),
-                    vol.Required("musicplayer_device"): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="media_player")
-                    ),
-                }
-            )
+            data_schema = vol.Schema(BASE_SCHEMA)
 
         # Show the form for the selected type
         return self.async_show_form(step_id="options", data_schema=data_schema)
+
+
+class ViewAssistOptionsFlowHandler(OptionsFlow):
+    """Handles the options flow.
+
+    Here we use an initial menu to select different options forms,
+    and show how to use api data to populate a selector.
+    """
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+        self.options = dict(config_entry.options)
+        self.type = self.config_entry.data["type"]
+
+    async def async_step_init(self, user_input=None):
+        """Handle options flow."""
+
+        # Display an options menu if display device
+        # Display reconfigure form if audio onlu
+
+        # Also need to be in strings.json and translation files.
+
+        if self.type == "view_audio":
+            return self.async_show_menu(
+                step_id="init",
+                menu_options=["main_config", "display_options"],
+            )
+
+        return await self.async_step_main_config()
+
+    async def async_step_main_config(self, user_input=None):
+        """Handle main config flow."""
+
+        if user_input is not None:
+            # This is just updating the core config so update config_entry.data
+            user_input["type"] = self.type
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, data=user_input
+            )
+            return self.async_create_entry(data=None)
+        # Define the schema based on the selected type
+        BASE_OPTIONS = {
+            vol.Required("name", default=self.config_entry.data["name"]): str,
+            vol.Required(
+                "mic_device", default=self.config_entry.data["mic_device"]
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=["sensor", "assist_satellite"])
+            ),
+            vol.Required(
+                "mediaplayer_device",
+                default=self.config_entry.data["mediaplayer_device"],
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="media_player")
+            ),
+            vol.Required(
+                "musicplayer_device",
+                default=self.config_entry.data["musicplayer_device"],
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="media_player")
+            ),
+        }
+
+        if self.type == "view_audio":
+            data_schema = vol.Schema(
+                {
+                    **BASE_OPTIONS,
+                    vol.Required(
+                        "display_device",
+                        default=self.config_entry.data["display_device"],
+                    ): selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="sensor")
+                    ),
+                    vol.Required(
+                        "browser_id", default=self.config_entry.data["browser_id"]
+                    ): str,
+                }
+            )
+        else:  # audio_only
+            data_schema = vol.Schema(BASE_OPTIONS)
+
+        # Show the form for the selected type
+        return self.async_show_form(step_id="main_config", data_schema=data_schema)
+
+    async def async_step_display_options(self, user_input=None):
+        """Handle display options flow."""
+        if user_input is not None:
+            # This is just updating the core config so update config_entry.data
+            return self.async_create_entry(data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Optional(
+                    "display_op1",
+                    default=self.config_entry.options.get("display_op1", "abc"),
+                ): str,
+                vol.Optional(
+                    "display_op2",
+                    default=self.config_entry.options.get("display_op2", "def"),
+                ): str,
+                vol.Optional(
+                    "display_op3",
+                    default=self.config_entry.options.get("display_op3", "ghi"),
+                ): str,
+                vol.Optional(
+                    "display_op4",
+                    default=self.config_entry.options.get("display_op4", "klm"),
+                ): str,
+            }
+        )
+
+        # Show the form for the selected type
+        return self.async_show_form(step_id="display_options", data_schema=data_schema)

--- a/custom_components/view_assist/services.yaml
+++ b/custom_components/view_assist/services.yaml
@@ -1,0 +1,21 @@
+navigate:
+  name: Navigate to a view
+  description: >
+    Command device to navigate to a certain view
+  fields:
+    device:
+      name: Device
+      description: The device to change screen on
+      example: "123434"
+      required: true
+      selector:
+        entity:
+          filter:
+            integration: view_assist
+    path:
+      name: View Path
+      description: Path in dashboard view
+      example: "view_assist/clock"
+      required: true
+      selector:
+        text:

--- a/custom_components/view_assist/translations/en.json
+++ b/custom_components/view_assist/translations/en.json
@@ -1,0 +1,63 @@
+{
+  "config": {
+    "title": "Advanced Config Flow Example",
+    "abort": {
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Reconfiguration successful",
+      "already_in_progress": "A setup is already in progress for this integration"
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "invalid_settings": "Invalid settings",
+      "unknown": "Unexpected error"
+    },
+    "step": {
+      "init": {
+        "title": "Configure a View Assist device",
+        "data": {
+          "name": "name",
+          "mic_device": "Microphone device",
+          "mediaplayer_device": "Media player device",
+          "musicplayer_device": "Music player device",
+          "display_device": "Display Device",
+          "browser_id": "Browser Id"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Reconfigure a View Assist device",
+        "description": "Select which options to amend.",
+        "menu_options": {
+          "main_config": "Main Configuration",
+          "display_options": "Display Options"
+        }
+      },
+      "main_config": {
+        "title": "Main Config",
+        "description": "Option Set 1",
+        "data": {
+          "name": "name",
+          "mic_device": "Microphone device",
+          "mediaplayer_device": "Media player device",
+          "musicplayer_device": "Music player device",
+          "display_device": "Display Device",
+          "browser_id": "Browser Id"
+        }
+      },
+      "display_options": {
+        "title": "Display Options",
+        "description": "Option Set 2",
+        "data": {
+          "option1": "Option 1",
+          "option2": "Option 2",
+          "option3": "Option 3",
+          "option4": "Option 4"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR give you a working navigate service with the following functionality:

1. Using dev tools, you can select your VAssist entity to call the service on.  This could be improved to allow multi entities.
2. You provide the path in the service call.
3. This will find the browser id from the integration instance config data
4. If browser id exists (ie display devicve) it will issue the service call to browser mod.
5. It will also create a call later in 10s to revert the display (by calling navigate again) to the clock view.

The delay and revert screen can all be changed to be configed or variable based on other things but hopefully this gives you the how to do.