### PR TITLE
set runtime vars initial values from corresponding config options

### DIFF
--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -49,9 +49,11 @@ class EntityListeners:
         new_state = event.data["new_state"]
         _LOGGER.info("OLD STATE: %s", old_state.state)
         _LOGGER.info("NEW STATE: %s", new_state.state)
+        self.config_entry.runtime_data.do_not_disturb = new_state.state == "on"
         if new_state.state == "on":
-            self.config_entry.runtime_data.status_icons = ["mic"]
-            self.update_entity()
+            if "mic" not in self.config_entry.runtime_data.status_icons:
+                self.config_entry.runtime_data.status_icons.append("mic")
+        self.update_entity()
 
     # Original attribute usage
     # @callback


### PR DESCRIPTION
In init.py
- we now have a function initialise_runtime_variables to set any defined attr in RuntimeData from any matching config.option key.  Has a little bit of fudgy code to deal with setting lists as string in config options.

In entity_listeners.py
- Just played around with the async_on_mic_change function to change attributes so you can see it working.

