### PR TITLE
fix for status icons not updating correctly

### DIFF
--- a/custom_components/view_assist/conversation.py
+++ b/custom_components/view_assist/conversation.py
@@ -1,0 +1,79 @@
+"""Handles entity listeners."""
+
+import logging
+from typing import Literal
+
+from hassil.recognize import RecognizeResult
+
+from homeassistant.components.conversation import (
+    DOMAIN as CONVERSATION_DOMAIN,
+    ConversationEntity,
+    ConversationInput,
+    ConversationResult,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CustomSentences:
+    """Class to manage custom senstence actions."""
+
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+        """Initialise."""
+        self.hass = hass
+        self.config_entry = config_entry
+
+        sentences = ["[whats] the weather", "[whats] the weather {when}"]
+
+        config_entry.async_on_unload(
+            hass.data[f"{CONVERSATION_DOMAIN}_default_entity"].register_trigger(
+                sentences, self.call_action
+            )
+        )
+
+    async def call_action(
+        self, user_input: ConversationInput, result: RecognizeResult
+    ) -> str | None:
+        """Call action with right context."""
+
+        # Add slot values as extra trigger data
+        details = {
+            entity_name: {
+                "name": entity_name,
+                "text": entity.text.strip(),  # remove whitespace
+                "value": (
+                    entity.value.strip()
+                    if isinstance(entity.value, str)
+                    else entity.value
+                ),
+            }
+            for entity_name, entity in result.entities.items()
+        }
+
+        _LOGGER.info(
+            "SENSTENCE TRIGGER %s",
+            {
+                "platform": CONVERSATION_DOMAIN,
+                "sentence": user_input.text,
+                "details": details,
+                "slots": {  # direct access to values
+                    entity_name: entity["value"]
+                    for entity_name, entity in details.items()
+                },
+                "device_id": user_input.device_id,
+                "user_input": user_input.as_dict(),
+            },
+        )
+        if self.config_entry.data["type"] == "view_audio":
+            await self.hass.services.async_call(
+                "browser_mod",
+                "navigate",
+                {
+                    "browser_id": "b7141f1b-c14cba93",
+                    "path": "/dashboard-view_assist/weather",
+                },
+            )
+
+        return "Showing weather view"

--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -2,12 +2,11 @@
 
 import logging
 
-from .const import VAConfigEntry
-from homeassistant.components.websocket_api.http import async_dispatcher_send
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_state_change_event
-from .const import DOMAIN
+
+from .const import DOMAIN, VAConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,11 +21,9 @@ class EntityListeners:
 
         mic_device = self.config_entry.data["mic_device"]
         mic_type = self.config_entry.options.get("mic_type")
-        mute_switch = get_mute_switch(mic_device, mic_type)
-
+        mute_switch = self.get_mute_switch(mic_device, mic_type)
 
         mediaplayer_device = self.config_entry.data["mediaplayer_device"]
-    
 
         # Add microphone mute switch listener
         config_entry.async_on_unload(
@@ -58,7 +55,6 @@ class EntityListeners:
     #             self.config_entry.runtime_data.status_icons.append("mic")
     #     self.update_entity()
 
-
     @callback
     def _async_on_mic_change(self, event: Event[EventStateChangedData]) -> None:
         old_state = event.data["old_state"]
@@ -66,25 +62,35 @@ class EntityListeners:
         _LOGGER.info("OLD STATE: %s", old_state.state)
         _LOGGER.info("NEW STATE: %s", new_state.state)
 
-
-
     @callback
     def _async_on_mediaplayer_device_mute_change(
         self, event: Event[EventStateChangedData]
     ) -> None:
-        new_state = event.data["new_state"]
-        mp_mute_new_state = new_state.attributes.get("is_volume_muted", False)
+        mp_mute_new_state = event.data["new_state"].attributes.get(
+            "is_volume_muted", False
+        )
+
+        # If not change to mute state, exit function
+        if (
+            not event.data.get("old_state")
+            or event.data["old_state"].attributes.get("is_volume_muted")
+            == mp_mute_new_state
+        ):
+            return
+
         _LOGGER.info("MP MUTE: %s", mp_mute_new_state)
-        if mp_mute_new_state is True:
-            self.config_entry.runtime_data.status_icons.append("mediaplayer")
-        elif mp_mute_new_state is False:
-            self.config_entry.runtime_data.status_icons.remove("mediaplayer")            
-        self.update_entity()            
+        status_icons = self.config_entry.runtime_data.status_icons.copy()
 
+        if mp_mute_new_state and "mediaplayer" not in status_icons:
+            status_icons.append("mediaplayer")
+        elif not mp_mute_new_state and "mediaplayer" in status_icons:
+            status_icons.remove("mediaplayer")
 
+        self.config_entry.runtime_data.status_icons = status_icons
+        self.update_entity()
 
-
-    def get_mute_switch(target_device, mic_type):
+    def get_mute_switch(self, target_device, mic_type):
+        """Get mute switch."""
         if mic_type == "Stream Assist":
             target_device = target_device.replace("sensor", "switch").replace(
                 "_stt", "_mic"

--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -20,7 +20,9 @@ class EntityListeners:
         self.config_entry = config_entry
 
         mic_device = self.config_entry.data["mic_device"]
-        mic_type = self.config_entry.options.get("mic_type")
+        mic_type = self.config_entry.options.get(
+            "mic_type", "Home Assistant Voice Satellite"
+        )
         mute_switch = self.get_mute_switch(mic_device, mic_type)
 
         mediaplayer_device = self.config_entry.data["mediaplayer_device"]
@@ -89,19 +91,16 @@ class EntityListeners:
         self.config_entry.runtime_data.status_icons = status_icons
         self.update_entity()
 
-    def get_mute_switch(self, target_device, mic_type):
+    def get_mute_switch(self, target_device: str, mic_type: str):
         """Get mute switch."""
+
         if mic_type == "Stream Assist":
-            target_device = target_device.replace("sensor", "switch").replace(
-                "_stt", "_mic"
-            )
-        elif mic_type == "HassMic":
-            target_device = target_device.replace("sensor", "switch").replace(
+            return target_device.replace("sensor", "switch").replace("_stt", "_mic")
+        if mic_type == "HassMic":
+            return target_device.replace("sensor", "switch").replace(
                 "simple_state", "microphone"
             )
-        elif mic_type == "Home Assistant Voice Satellite":
-            target_device = (
-                target_device.replace("assist_satellite", "switch") + "_mute"
-            )
+        if mic_type == "Home Assistant Voice Satellite":
+            return target_device.replace("assist_satellite", "switch") + "_mute"
 
-        return target_device
+        return None

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -115,7 +115,7 @@ class ViewAssistSensor(SensorEntity):
 
         # Add named attributes from runtime data
         for k in self.config.runtime_data.__dict__:
-            if not k.startswith("_") and not k.startswith("__") and k != "extra_data":
+            if not k.startswith(("_", "__")) and k != "extra_data":
                 attrs[k] = getattr(self.config.runtime_data, k)
 
         # Add extra_data attributes from runtime data

--- a/custom_components/view_assist/timers.py
+++ b/custom_components/view_assist/timers.py
@@ -1,0 +1,65 @@
+"""Class to handle persistent storage."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import datetime as dt
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HassJob, HomeAssistant, callback
+from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STORE_NAME = DOMAIN
+
+
+@dataclass
+class Timer:
+    """Class to hold timer."""
+
+    id: int
+    expires: dt.datetime
+    name: str | None = None
+    callback: Callable | None = None
+    cancel: Callable | None = None
+
+
+class VATimers:
+    """Class to handle VA timers."""
+
+    def __init__(self, hass: HomeAssistant, config: ConfigEntry):
+        """Initialise."""
+        self.hass = hass
+        self.config = config
+
+        self._store = Store[list[Timer]](hass, 1, STORE_NAME)
+        self.timers: list[Timer] = []
+
+    async def load(self):
+        """Load data store."""
+        self.timers = await self._store.async_load()
+
+    async def add_timer(self, timer: Timer):
+        """Add timer to store."""
+        timer_cancel = async_track_point_in_time(
+            self.hass,
+            HassJob(
+                self._timer_expired_callback,
+                f"Timer{timer.id}",
+                cancel_on_shutdown=False,
+            ),
+            timer.expires,
+        )
+        # timer.cancel = timer_cancel
+        self.timers.append(timer)
+        await self._store.async_save(self.timers)
+
+        _LOGGER.warning("TIMERS: %s", self.timers)
+
+    @callback
+    def _timer_expired_callback(self, *args):
+        _LOGGER.info("TIMER EXPIRED: %s", args)


### PR DESCRIPTION
Ok, so having played around with this for some time, I think there must be something to do with caching affecting this updating on the attributes.  To get around this, I have created a copy of the status_icons, updated that copy and then written that back to config.runtime_data.status_icons.  This way it is forcing the cache to update and the attributes update immediately.

I would guess that we may find this type of issue with any complex data type (lists, dicts etc), I think str and bool are fine.