### PR TITLE
Set config values into runtime data at startup

### DIFF
--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -2,30 +2,92 @@
 
 import voluptuous as vol
 
+from homeassistant.components.assist_satellite import DOMAIN as ASSIST_SAT_DOMAIN
+from homeassistant.components.media_player import DOMAIN as MEDIAPLAYER_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.const import CONF_MODE, CONF_NAME, CONF_TYPE
 from homeassistant.core import callback
-from homeassistant.helpers import selector
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.selector import (
+    EntitySelector,
+    EntitySelectorConfig,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
-from .const import DOMAIN
+from .const import (
+    CONF_ASSIST_PROMPT,
+    CONF_BACKGROUND,
+    CONF_BROWSER_ID,
+    CONF_DASHBOARD,
+    CONF_DISPLAY_DEVICE,
+    CONF_DISPLAY_TYPE,
+    CONF_DO_NOT_DISTURB,
+    CONF_FONT_STYLE,
+    CONF_HOME,
+    CONF_INTENT,
+    CONF_MEDIAPLAYER_DEVICE,
+    CONF_MIC_DEVICE,
+    CONF_MIC_TYPE,
+    CONF_MIC_UNMUTE,
+    CONF_MUSIC,
+    CONF_MUSICPLAYER_DEVICE,
+    CONF_STATUS_ICON_SIZE,
+    CONF_STATUS_ICONS,
+    CONF_USE_24H_TIME,
+    CONF_USE_ANNOUNCE,
+    CONF_VIEW_TIMEOUT,
+    CONF_WEATHER_ENTITY,
+    DEFAULT_ASSIST_PROMPT,
+    DEFAULT_DASHBOARD,
+    DEFAULT_DISPLAY_TYPE,
+    DEFAULT_DND,
+    DEFAULT_FONT_STYLE,
+    DEFAULT_MIC_TYPE,
+    DEFAULT_MIC_UNMUTE,
+    DEFAULT_MODE,
+    DEFAULT_NAME,
+    DEFAULT_STATUS_ICON_SIZE,
+    DEFAULT_STATUS_ICONS,
+    DEFAULT_TYPE,
+    DEFAULT_USE_24H_TIME,
+    DEFAULT_USE_ANNOUNCE,
+    DEFAULT_VIEW_BACKGROUND,
+    DEFAULT_VIEW_HOME,
+    DEFAULT_VIEW_INTENT,
+    DEFAULT_VIEW_MUSIC,
+    DEFAULT_VIEW_TIMEOUT,
+    DEFAULT_WEATHER_ENITITY,
+    DOMAIN,
+    VAAssistPrompt,
+    VAConfigEntry,
+    VADisplayType,
+    VAIconSizes,
+    VAMicType,
+    VAType,
+)
 
 BASE_SCHEMA = {
-    vol.Required("name"): str,
-    vol.Required("mic_device"): selector.EntitySelector(
-        selector.EntitySelectorConfig(domain=["sensor", "assist_satellite"])
+    vol.Required(CONF_NAME): str,
+    vol.Required(CONF_MIC_DEVICE): EntitySelector(
+        EntitySelectorConfig(domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN])
     ),
-    vol.Required("mediaplayer_device"): selector.EntitySelector(
-        selector.EntitySelectorConfig(domain="media_player")
+    vol.Required(CONF_MEDIAPLAYER_DEVICE): EntitySelector(
+        EntitySelectorConfig(domain=MEDIAPLAYER_DOMAIN)
     ),
-    vol.Required("musicplayer_device"): selector.EntitySelector(
-        selector.EntitySelectorConfig(domain="media_player")
+    vol.Required(CONF_MUSICPLAYER_DEVICE): EntitySelector(
+        EntitySelectorConfig(domain=MEDIAPLAYER_DOMAIN)
     ),
 }
 
 DISPLAY_SCHEMA = {
-    vol.Required("display_device"): selector.EntitySelector(
-        selector.EntitySelectorConfig(domain="sensor")
+    vol.Required(CONF_DISPLAY_DEVICE): EntitySelector(
+        EntitySelectorConfig(domain=SENSOR_DOMAIN)
     ),
-    vol.Required("browser_id"): str,
+    vol.Required(CONF_BROWSER_ID): str,
 }
 
 
@@ -51,7 +113,7 @@ class ViewAssistConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         if user_input is not None:
-            self.type = user_input["type"]
+            self.type = user_input[CONF_TYPE]
             return await self.async_step_options()
 
         # Show the initial form to select the type with descriptive text
@@ -60,19 +122,11 @@ class ViewAssistConfigFlow(ConfigFlow, domain=DOMAIN):
             last_step=False,
             data_schema=vol.Schema(
                 {
-                    vol.Required("type", default="view_audio"): selector.SelectSelector(
-                        selector.SelectSelectorConfig(
-                            options=[
-                                {
-                                    "value": "view_audio",
-                                    "label": "View Assist device with display",
-                                },
-                                {
-                                    "value": "audio_only",
-                                    "label": "View Assist device with no display",
-                                },
-                            ],
-                            mode="dropdown",
+                    vol.Required(CONF_TYPE, default=DEFAULT_TYPE): SelectSelector(
+                        SelectSelectorConfig(
+                            translation_key="type_selector",
+                            options=[e.value for e in VAType],
+                            mode=SelectSelectorMode.DROPDOWN,
                         )
                     ),
                 }
@@ -83,13 +137,13 @@ class ViewAssistConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the options step."""
         if user_input is not None:
             # Include the type in the data to save in the config entry
-            user_input["type"] = self.type
+            user_input[CONF_TYPE] = self.type
             return self.async_create_entry(
-                title=user_input.get("name", "View Assist"), data=user_input
+                title=user_input.get(CONF_NAME, DEFAULT_NAME), data=user_input
             )
 
         # Define the schema based on the selected type
-        if self.type == "view_audio":
+        if self.type == VAType.VIEW_AUDIO:
             data_schema = vol.Schema({**BASE_SCHEMA, **DISPLAY_SCHEMA})
         else:  # audio_only
             data_schema = vol.Schema(BASE_SCHEMA)
@@ -105,21 +159,21 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
     and show how to use api data to populate a selector.
     """
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
+    def __init__(self) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
-        self.options = dict(config_entry.options)
-        self.type = self.config_entry.data["type"]
+        # self.options = dict(config_entry.options)
+        # self.type = self.config_entry.data[CONF_TYPE]
 
     async def async_step_init(self, user_input=None):
         """Handle options flow."""
+        va_type = self.config_entry.data[CONF_TYPE]
 
         # Display an options menu if display device
         # Display reconfigure form if audio only
 
         # Also need to be in strings.json and translation files.
 
-        if self.type == "view_audio":
+        if va_type == VAType.VIEW_AUDIO:
             return self.async_show_menu(
                 step_id="init",
                 menu_options=["main_config", "dashboard_options", "default_options"],
@@ -132,45 +186,39 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
 
         if user_input is not None:
             # This is just updating the core config so update config_entry.data
-            user_input["type"] = self.type
+            user_input[CONF_TYPE] = self.type
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=user_input
             )
             return self.async_create_entry(data=None)
         # Define the schema based on the selected type
         BASE_OPTIONS = {
-            vol.Required("name", default=self.config_entry.data["name"]): str,
+            vol.Required(CONF_NAME, default=self.config_entry.data[CONF_NAME]): str,
             vol.Required(
-                "mic_device", default=self.config_entry.data["mic_device"]
-            ): selector.EntitySelector(
-                selector.EntitySelectorConfig(domain=["sensor", "assist_satellite"])
+                CONF_MIC_DEVICE, default=self.config_entry.data[CONF_MIC_DEVICE]
+            ): EntitySelector(
+                EntitySelectorConfig(domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN])
             ),
             vol.Required(
-                "mediaplayer_device",
-                default=self.config_entry.data["mediaplayer_device"],
-            ): selector.EntitySelector(
-                selector.EntitySelectorConfig(domain="media_player")
-            ),
+                CONF_MEDIAPLAYER_DEVICE,
+                default=self.config_entry.data[CONF_MEDIAPLAYER_DEVICE],
+            ): EntitySelector(EntitySelectorConfig(domain=MEDIAPLAYER_DOMAIN)),
             vol.Required(
-                "musicplayer_device",
-                default=self.config_entry.data["musicplayer_device"],
-            ): selector.EntitySelector(
-                selector.EntitySelectorConfig(domain="media_player")
-            ),
+                CONF_MUSICPLAYER_DEVICE,
+                default=self.config_entry.data[CONF_MUSICPLAYER_DEVICE],
+            ): EntitySelector(EntitySelectorConfig(domain=MEDIAPLAYER_DOMAIN)),
         }
 
-        if self.type == "view_audio":
+        if self.type == VAType.VIEW_AUDIO:
             data_schema = vol.Schema(
                 {
                     **BASE_OPTIONS,
                     vol.Required(
-                        "display_device",
-                        default=self.config_entry.data["display_device"],
-                    ): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="sensor")
-                    ),
+                        CONF_DISPLAY_DEVICE,
+                        default=self.config_entry.data[CONF_DISPLAY_DEVICE],
+                    ): EntitySelector(EntitySelectorConfig(domain=SENSOR_DOMAIN)),
                     vol.Required(
-                        "browser_id", default=self.config_entry.data["browser_id"]
+                        CONF_BROWSER_ID, default=self.config_entry.data[CONF_BROWSER_ID]
                     ): str,
                 }
             )
@@ -189,66 +237,82 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
         data_schema = vol.Schema(
             {
                 vol.Optional(
-                    "dashboard",
-                    default=self.config_entry.options.get("dashboard", "/dashboard-viewassist"),
-                ): str,
-                vol.Optional(
-                    "home",
-                    default=self.config_entry.options.get("home", "/dashboard-viewassist/clock"),
-                ): str,
-                vol.Optional(
-                    "music",
-                    default=self.config_entry.options.get("music", "/dashboard-viewassist/music"),
-                ): str,
-                vol.Optional(
-                    "intent",
-                    default=self.config_entry.options.get("intent", "/dashboard-viewassist/intent"),
-                ): str,
-                vol.Optional(
-                    "background",
-                    default=self.config_entry.options.get("background", "/local/viewassist/backgrounds/mybackground.jpg"),
-                ): str,                
-                vol.Optional(
-                    "assist_prompt",
+                    CONF_DASHBOARD,
                     default=self.config_entry.options.get(
-                        "assist_prompt", "blur pop up"
+                        CONF_DASHBOARD, DEFAULT_DASHBOARD
                     ),
-                ): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
+                ): str,
+                vol.Optional(
+                    CONF_HOME,
+                    default=self.config_entry.options.get(CONF_HOME, DEFAULT_VIEW_HOME),
+                ): str,
+                vol.Optional(
+                    CONF_MUSIC,
+                    default=self.config_entry.options.get(
+                        CONF_MUSIC, DEFAULT_VIEW_MUSIC
+                    ),
+                ): str,
+                vol.Optional(
+                    CONF_INTENT,
+                    default=self.config_entry.options.get(
+                        CONF_INTENT, DEFAULT_VIEW_INTENT
+                    ),
+                ): str,
+                vol.Optional(
+                    CONF_BACKGROUND,
+                    default=self.config_entry.options.get(
+                        CONF_BACKGROUND, DEFAULT_VIEW_BACKGROUND
+                    ),
+                ): str,
+                vol.Optional(
+                    CONF_ASSIST_PROMPT,
+                    default=self.config_entry.options.get(
+                        CONF_ASSIST_PROMPT, DEFAULT_ASSIST_PROMPT
+                    ),
+                ): SelectSelector(
+                    SelectSelectorConfig(
                         translation_key="assist_prompt_selector",
-                        options=["blur pop up", "flashing bar"],
-                        mode="dropdown",
+                        options=[e.value for e in VAAssistPrompt],
+                        mode=SelectSelectorMode.DROPDOWN,
                     )
                 ),
                 vol.Optional(
-                    "status_icons_size",
+                    CONF_STATUS_ICON_SIZE,
                     default=self.config_entry.options.get(
-                        "status_icons_size", "Large"
+                        CONF_STATUS_ICON_SIZE, DEFAULT_STATUS_ICON_SIZE
                     ),
-                ): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
+                ): SelectSelector(
+                    SelectSelectorConfig(
                         translation_key="status_icons_size_selector",
-                        options=["Small", "Medium", "Large"],
-                        mode="dropdown",
+                        options=[e.value for e in VAIconSizes],
+                        mode=SelectSelectorMode.DROPDOWN,
                     )
                 ),
                 vol.Optional(
-                    "font_style",
-                    default=self.config_entry.options.get("font_style", "Roboto"),
+                    CONF_FONT_STYLE,
+                    default=self.config_entry.options.get(
+                        CONF_FONT_STYLE, DEFAULT_FONT_STYLE
+                    ),
                 ): str,
                 vol.Optional(
-                    "status_icons",
-                    default=self.config_entry.options.get("status_icons", "[]"),
+                    CONF_STATUS_ICONS,
+                    default=self.config_entry.options.get(
+                        CONF_STATUS_ICONS, DEFAULT_STATUS_ICONS
+                    ),
                 ): str,
                 vol.Optional(
-                    "use_24_hour_time",
-                    default=self.config_entry.options.get("use_24_hour_time", False),
+                    CONF_USE_24H_TIME,
+                    default=self.config_entry.options.get(
+                        CONF_USE_24H_TIME, DEFAULT_USE_24H_TIME
+                    ),
                 ): bool,
             }
         )
 
         # Show the form for the selected type
-        return self.async_show_form(step_id="dashboard_options", data_schema=data_schema)
+        return self.async_show_form(
+            step_id="dashboard_options", data_schema=data_schema
+        )
 
     async def async_step_default_options(self, user_input=None):
         """Handle default options flow."""
@@ -257,62 +321,67 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
             return self.async_create_entry(data=user_input)
 
         data_schema = vol.Schema(
-            {          
+            {
                 vol.Optional(
-                    "weather_entity",
-                    default=self.config_entry.options.get("weather_entity", "weather.home"),
-                ): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="weather")
-                ),
-                vol.Optional(
-                    "mic_type",
+                    CONF_WEATHER_ENTITY,
                     default=self.config_entry.options.get(
-                        "mic_type", "Home Assistant Voice Satellite"
+                        CONF_WEATHER_ENTITY, DEFAULT_WEATHER_ENITITY
                     ),
-                ): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
+                ): EntitySelector(EntitySelectorConfig(domain=WEATHER_DOMAIN)),
+                vol.Optional(
+                    CONF_MIC_TYPE,
+                    default=self.config_entry.options.get(
+                        CONF_MIC_TYPE, DEFAULT_MIC_TYPE
+                    ),
+                ): SelectSelector(
+                    SelectSelectorConfig(
                         translation_key="mic_type_selector",
-                        options=["Home Assistant Voice Satellite", "HassMic", "Stream Assist"],
-                        mode="dropdown",
+                        options=[e.value for e in VAMicType],
+                        mode=SelectSelectorMode.DROPDOWN,
                     )
                 ),
                 vol.Optional(
-                    "display_type",
+                    CONF_DISPLAY_TYPE,
                     default=self.config_entry.options.get(
-                        "display_type", "BrowserMod"
+                        CONF_DISPLAY_TYPE, DEFAULT_DISPLAY_TYPE
                     ),
-                ): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
+                ): SelectSelector(
+                    SelectSelectorConfig(
                         translation_key="display_type_selector",
-                        options=["BrowserMod", "Remote Assist Display"],
-                        mode="dropdown",
+                        options=[e.value for e in VADisplayType],
+                        mode=SelectSelectorMode.DROPDOWN,
                     )
-                ),                                                     
+                ),
                 vol.Optional(
-                    "mode",
-                    default=self.config_entry.options.get("mode", "normal"),
+                    CONF_MODE,
+                    default=self.config_entry.options.get(CONF_MODE, DEFAULT_MODE),
                 ): str,
                 vol.Optional(
-                    "view_timeout",
-                    default=self.config_entry.options.get("view_timeout", "20"),
+                    CONF_VIEW_TIMEOUT,
+                    default=self.config_entry.options.get(
+                        CONF_VIEW_TIMEOUT, DEFAULT_VIEW_TIMEOUT
+                    ),
                 ): str,
                 vol.Optional(
-                    "do_not_disturb",
-                    default=self.config_entry.options.get("do_not_disturb", False),
-                ): bool,                
+                    CONF_DO_NOT_DISTURB,
+                    default=self.config_entry.options.get(
+                        CONF_DO_NOT_DISTURB, DEFAULT_DND
+                    ),
+                ): bool,
                 vol.Optional(
-                    "use_announce",
-                    default=self.config_entry.options.get("use_announce", True),
-                ): bool,                                                
+                    CONF_USE_ANNOUNCE,
+                    default=self.config_entry.options.get(
+                        CONF_USE_ANNOUNCE, DEFAULT_USE_ANNOUNCE
+                    ),
+                ): bool,
                 vol.Optional(
-                    "micunmute",
-                    default=self.config_entry.options.get("use_announce", False),
-                ): bool,                
+                    CONF_MIC_UNMUTE,
+                    default=self.config_entry.options.get(
+                        CONF_MIC_UNMUTE, DEFAULT_MIC_UNMUTE
+                    ),
+                ): bool,
             }
         )
 
         # Show the form for the selected type
         return self.async_show_form(step_id="default_options", data_schema=data_schema)
-    
-
-    

--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -104,7 +104,7 @@ class ViewAssistConfigFlow(ConfigFlow, domain=DOMAIN):
         Remove this method and the ExampleOptionsFlowHandler class
         if you do not want any options for your integration.
         """
-        return ViewAssistOptionsFlowHandler(config_entry)
+        return ViewAssistOptionsFlowHandler()
 
     def __init__(self) -> None:
         """Initialise."""
@@ -158,11 +158,6 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
     Here we use an initial menu to select different options forms,
     and show how to use api data to populate a selector.
     """
-
-    def __init__(self) -> None:
-        """Initialize options flow."""
-        # self.options = dict(config_entry.options)
-        # self.type = self.config_entry.data[CONF_TYPE]
 
     async def async_step_init(self, user_input=None):
         """Handle options flow."""

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -1,4 +1,6 @@
-from dataclasses import dataclass, field
+"""Integration classes and constants."""
+
+from enum import StrEnum
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -8,11 +10,133 @@ DOMAIN = "view_assist"
 type VAConfigEntry = ConfigEntry[RuntimeData]
 
 
-@dataclass
+class VAMode(StrEnum):
+    """View Assist modes."""
+
+    NORMAL = "normal"
+
+
+class VAType(StrEnum):
+    """Sensor type enum."""
+
+    VIEW_AUDIO = "view_audio"
+    AUDIO_ONLY = "audio_only"
+
+
+class VAAssistPrompt(StrEnum):
+    """Assist prompt types enum."""
+
+    BLUR_POPUP = "blur pop up"
+    FLASHING_BAR = "flashing bar"
+
+
+class VAIconSizes(StrEnum):
+    """Icon size options enum."""
+
+    SMALL = "Small"
+    MEDIUM = "Medium"
+    LARGE = "Large"
+
+
+class VAMicType(StrEnum):
+    """Mic types."""
+
+    HA_VOICE_SATELLITE = "Home Assistant Voice Satellite"
+    HASS_MIC = "HassMic"
+    STREAM_ASSIST = "Stream Assist"
+
+
+class VADisplayType(StrEnum):
+    """Display types."""
+
+    BROWSERMOD = "BrowserMod"
+    REMOTE_ASSIST_DISPLAY = "Remote Assist Display"
+
+
 class RuntimeData:
     """Class to hold your data."""
 
-    mode: str = "normal"
-    do_not_disturb: bool = False
-    status_icons: list[str] = field(default_factory=list)
-    extra_data: dict[str, Any] = field(default_factory=dict)
+    def __init__(self) -> None:
+        """Initialise runtime data."""
+        # Runtime variables go here
+
+        # Default config
+        self.type: VAType | None = None
+        self.name: str = ""
+        self.mic_device: str = ""
+        self.mediaplayer_device: str = ""
+        self.musicplayer_device: str = ""
+        self.display_device: str = ""
+        self.browser_id: str = ""
+
+        # Dashboard options
+        self.dashboard: str = DEFAULT_DASHBOARD
+        self.home: str = DEFAULT_VIEW_HOME
+        self.music: str = DEFAULT_VIEW_MUSIC
+        self.intent: str = DEFAULT_VIEW_INTENT
+        self.background: str = DEFAULT_VIEW_BACKGROUND
+        self.assist_prompt: VAAssistPrompt = DEFAULT_ASSIST_PROMPT
+        self.status_icons_size: VAIconSizes = DEFAULT_STATUS_ICON_SIZE
+        self.font_style: str = DEFAULT_FONT_STYLE
+        self.status_icons: list[str] = DEFAULT_STATUS_ICONS
+        self.use_24h_time: bool = DEFAULT_USE_24H_TIME
+
+        # Default options
+        self.weather_entity: str = DEFAULT_WEATHER_ENITITY
+        self.mic_type: VAMicType = DEFAULT_MIC_TYPE
+        self.display_type: VADisplayType = DEFAULT_DISPLAY_TYPE
+        self.mode: str = DEFAULT_MODE
+        self.view_timeout: int = DEFAULT_VIEW_TIMEOUT
+        self.do_not_disturb: bool = DEFAULT_DND
+        self.use_announce: bool = DEFAULT_USE_ANNOUNCE
+        self.mic_unmute: bool = DEFAULT_MIC_UNMUTE
+
+        # Extra data for holding key/value pairs passed in by set_state service call
+        self.extra_data: dict[str, Any] = {}
+
+
+# Config keys
+CONF_MIC_DEVICE = "mic_device"
+CONF_MEDIAPLAYER_DEVICE = "mediaplayer_device"
+CONF_MUSICPLAYER_DEVICE = "musicplayer_device"
+CONF_DISPLAY_DEVICE = "display_device"
+CONF_BROWSER_ID = "browser_id"
+CONF_DASHBOARD = "dashboard"
+CONF_HOME = "home"
+CONF_INTENT = "intent"
+CONF_MUSIC = "music"
+CONF_BACKGROUND = "background"
+CONF_ASSIST_PROMPT = "assist_prompt"
+CONF_STATUS_ICON_SIZE = "status_icons_size"
+CONF_FONT_STYLE = "font_style"
+CONF_STATUS_ICONS = "status_icons"
+CONF_USE_24H_TIME = "use_24_hour_time"
+CONF_WEATHER_ENTITY = "weather_entity"
+CONF_MIC_TYPE = "mic_type"
+CONF_DISPLAY_TYPE = "display_type"
+CONF_VIEW_TIMEOUT = "view_timeout"
+CONF_DO_NOT_DISTURB = "do_not_disturb"
+CONF_USE_ANNOUNCE = "use_announce"
+CONF_MIC_UNMUTE = "micunmute"
+
+# Config default values
+DEFAULT_NAME = "View Assist"
+DEFAULT_TYPE = VAType.VIEW_AUDIO
+DEFAULT_DASHBOARD = "/dashboard-viewassist"
+DEFAULT_VIEW_HOME = "/dashboard-viewassist/clock"
+DEFAULT_VIEW_MUSIC = "/dashboard-viewassist/music"
+DEFAULT_VIEW_INTENT = "/dashboard-viewassist/intent"
+DEFAULT_VIEW_BACKGROUND = "/local/viewassist/backgrounds/mybackground.jpg"
+DEFAULT_ASSIST_PROMPT = VAAssistPrompt.BLUR_POPUP
+DEFAULT_STATUS_ICON_SIZE = VAIconSizes.LARGE
+DEFAULT_FONT_STYLE = "Roboto"
+DEFAULT_STATUS_ICONS = []
+DEFAULT_USE_24H_TIME = False
+DEFAULT_WEATHER_ENITITY = "weather.home"
+DEFAULT_MIC_TYPE = VAMicType.HA_VOICE_SATELLITE
+DEFAULT_DISPLAY_TYPE = VADisplayType.BROWSERMOD
+DEFAULT_MODE = "normal"
+DEFAULT_VIEW_TIMEOUT = 20
+DEFAULT_DND = False
+DEFAULT_USE_ANNOUNCE = True
+DEFAULT_MIC_UNMUTE = False

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -1,0 +1,10 @@
+"""Helper functions."""
+
+
+def ensure_list(value: str | list[str]):
+    """Ensure that a value is a list."""
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        return (value.replace("[", "").replace("]", "").replace('"', "")).split(",")
+    return []

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -40,33 +40,9 @@ class ViewAssistSensor(SensorEntity):
 
         self.config = config
 
-        self._attr_name = config.data["name"]
-        self._type = config.data["type"]
+        self._attr_name = config.runtime_data.name
+        self._type = config.runtime_data.type
         self._attr_unique_id = f"{self._attr_name}_vasensor"
-        self._mic_device = config.data["mic_device"]
-        self._mediaplayer_device = config.data["mediaplayer_device"]
-        self._musicplayer_device = config.data["musicplayer_device"]
-        self._mode = config.options.get("mode", "normal")
-        self._view_timeout = config.options.get("view_timeout", "20")
-        self._do_not_disturb = config.options.get("do_not_disturb", False)
-        self._status_icons = config.options.get("status_icons", "[]")
-        self._status_icons_size = config.options.get("status_icons_size", "8vw")
-        self._status_assist_prompt = config.options.get("assist_prompt", "blur pop up")
-        self._font_style = config.options.get("font_style", "Roboto")
-        self._use_24_hour_time = config.options.get("use_24_hour_time", False)
-        self._use_announce = config.options.get("use_announce", True)
-        self._background = config.options.get(
-            "background", "/local/viewassist/backgrounds/mybackground.jpg"
-        )
-        self._weather_entity = config.options.get("weather_entity", "weather.home")
-        self._mic_type = config.options.get(
-            "mic_type", "Home Assistant Voice Satellite"
-        )
-        self._display_type = config.options.get("display_type", "BrowserMod")
-        self._display_device = config.data.get(
-            "display_device"
-        )  # Optional for audio_only
-        self._browser_id = config.data.get("browser_id")  # Optional for audio_only
         self._attr_native_value = ""
 
     async def async_added_to_hass(self) -> None:
@@ -87,36 +63,32 @@ class ViewAssistSensor(SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return entity attributes."""
+        r = self.config.runtime_data
         attrs = {
-            "type": self._type,
-            "mic_device": self._mic_device,
-            "mediaplayer_device": self._mediaplayer_device,
-            "musicplayer_device": self._musicplayer_device,
-            # "mode": self._mode,
-            "view_timeout": self._view_timeout,
-            # "do_not_disturb": self._do_not_disturb,
-            # "status_icons": self._status_icons,
-            "status_icons_size": self._status_icons_size,
-            "status_assist_prompt": self._status_assist_prompt,
-            "font_style": self._font_style,
-            "use_24_hour_time": self._use_24_hour_time,
-            "use_announce": self._use_announce,
-            "background": self._background,
-            "weather_entity": self._weather_entity,
-            "mic_type": self._mic_type,
-            "display_type": self._display_type,
+            "type": r.type,
+            "mic_device": r.mic_device,
+            "mediaplayer_device": r.mediaplayer_device,
+            "musicplayer_device": r.musicplayer_device,
+            "mode": r.mode,
+            "view_timeout": r.view_timeout,
+            "do_not_disturb": r.do_not_disturb,
+            "status_icons": r.status_icons,
+            "status_icons_size": r.status_icons_size,
+            "status_assist_prompt": r.assist_prompt,
+            "font_style": r.font_style,
+            "use_24_hour_time": r.use_24h_time,
+            "use_announce": r.use_announce,
+            "background": r.background,
+            "weather_entity": r.weather_entity,
+            "mic_type": r.mic_type,
+            "display_type": r.display_type,
         }
 
         # Only add these attributes if they exist
-        if self._display_device:
-            attrs["display_device"] = self._display_device
-        if self._browser_id:
-            attrs["browser_id"] = self._browser_id
-
-        # Add named attributes from runtime data
-        for k in self.config.runtime_data.__dict__:
-            if not k.startswith(("_", "__")) and k != "extra_data":
-                attrs[k] = getattr(self.config.runtime_data, k)
+        if r.display_device:
+            attrs["display_device"] = r.display_device
+        if r.browser_id:
+            attrs["browser_id"] = r.browser_id
 
         # Add extra_data attributes from runtime data
         attrs.update(self.config.runtime_data.extra_data)

--- a/custom_components/view_assist/services.py
+++ b/custom_components/view_assist/services.py
@@ -1,0 +1,138 @@
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_DEVICE, CONF_PATH
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
+from homeassistant.helpers import entity_registry as er, selector
+from homeassistant.helpers.event import partial
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+NAVIGATE_SERVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE): selector.EntitySelector(
+            selector.EntitySelectorConfig(integration=DOMAIN)
+        ),
+        vol.Required(CONF_PATH): str,
+    }
+)
+
+
+async def setup_services(hass: HomeAssistant):
+    """Initialise VA services."""
+    ##################
+    # Get Target Satellite
+    # Used to determine which VA satellite is being used based on its microphone device
+    #
+    # Sample usage
+    # action: view_assist.get_target_satellite
+    # data:
+    #   device_id: 4385828338e48103f63c9f91756321df
+
+    async def handle_get_target_satellite(call: ServiceCall) -> ServiceResponse:
+        """Handle a get target satellite lookup call."""
+        device_id = call.data.get("device_id")
+        entity_registry = er.async_get(hass)
+
+        entities = []
+
+        entry_ids = [
+            entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN)
+        ]
+
+        for entry_id in entry_ids:
+            integration_entities = er.async_entries_for_config_entry(
+                entity_registry, entry_id
+            )
+            entity_ids = [entity.entity_id for entity in integration_entities]
+            entities.extend(entity_ids)
+
+        # Fetch the 'mic_device' attribute for each entity
+        # compare the device_id of mic_device to the value passed in to the service
+        # return the match for the satellite that contains that mic_device
+        target_satellite_devices = []
+        for entity_id in entities:
+            if state := hass.states.get(entity_id):
+                if mic_entity_id := state.attributes.get("mic_device"):
+                    if mic_entity := entity_registry.async_get(mic_entity_id):
+                        if mic_entity.device_id == device_id:
+                            target_satellite_devices.append(entity_id)
+
+        # Return the list of target_satellite_devices
+        # This should match only one VA device
+        return {"target_satellite": target_satellite_devices}
+
+    hass.services.async_register(
+        DOMAIN,
+        "get_target_satellite",
+        handle_get_target_satellite,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    #########
+
+    #########
+    # Handle Navigation
+    # Used to determine how to change the view on the VA device
+    #
+    # action: view_assist.navigate
+    # data:
+    #   target_display_device: sensor.viewassist_office_browser_path
+    #   target_display_type: browsermod
+    #   path: /dashboard-viewassist/weather
+    #
+    async def handle_navigate(call: ServiceCall):
+        """Handle a navigate to view call."""
+        va_entity_id = call.data.get("device")
+        path = call.data.get("path")
+
+        # get config entry from entity id to allow access to browser_id parameter
+        entity_registry = er.async_get(hass)
+        if entity := entity_registry.async_get(va_entity_id):
+            entity_config_entry = hass.config_entries.async_get_entry(
+                entity.config_entry_id
+            )
+            browser_id = entity_config_entry.data.get("browser_id")
+
+            if browser_id:
+                await browser_navigate(browser_id, path, "/view_assist/clock")
+
+    hass.services.async_register(
+        DOMAIN, "navigate", handle_navigate, schema=NAVIGATE_SERVICE_SCHEMA
+    )
+
+    async def browser_navigate(
+        browser_id: str,
+        path: str,
+        revert_path: str | None = None,
+        timeout: int = 10,
+    ):
+        """Navigate browser to defined view.
+
+        Optionally revert to another view after timeout.
+        """
+        _LOGGER.debug("Navigating: browser_id: %s, path: %s", browser_id, path)
+        await hass.services.async_call(
+            "browser_mod",
+            "navigate",
+            {"browser_id": browser_id, "path": path},
+        )
+
+        if revert_path and timeout:
+            _LOGGER.debug("Adding revert to %s in %ss", revert_path, timeout)
+            hass.loop.call_later(
+                10,
+                partial(
+                    hass.create_task,
+                    browser_navigate(browser_id, revert_path),
+                    f"Revert browser {browser_id}",
+                ),
+            )

--- a/custom_components/view_assist/translations/en.json
+++ b/custom_components/view_assist/translations/en.json
@@ -55,7 +55,7 @@
           "musicplayer_device": "The music player device for this satellite",
           "display_device": "The display device for this satellite",
           "browser_id": "The browser id for this satellite"
-        }        
+        }
       },
       "dashboard_options": {
         "title": "Dashboard Options",
@@ -81,7 +81,7 @@
           "status_icons_size": "Size of the icons in the status icon display",
           "font_style": "The default font to use for this satellite device. Font name must match perfectly and be available",
           "status_icons": "Advanced option! List of custom launch icons to set on start up. Do not change this if you do not know what you are doing"
-        }        
+        }
       },
       "default_options": {
         "title": "Default Options",
@@ -99,11 +99,17 @@
         "data_description": {
           "mode": "The default mode for this satellite device",
           "view_timeout": "The default time out value for this satellite device in seconds before returning to default view"
-        }        
-      }      
+        }
+      }
     }
   },
   "selector": {
+    "type_selector": {
+      "options": {
+        "view_audio": "View Assist device with display",
+        "audio_only": "View Assist device with no display"
+      }
+    },
     "assist_prompt_selector": {
       "options": {
         "blur pop up": "Blurs the screen and shows pop up",
@@ -115,21 +121,21 @@
           "Small": "Small",
           "Medium": "Medium",
           "Large": "Large"
-        }      
+        }
     },
     "mic_type_selector": {
       "options": {
         "Home Assistant Voice Satellite": "Home Assistant Voice Satellite",
         "HassMic": "HassMic",
         "Stream Assist": "Stream Assist"
-      }      
+      }
     },
     "display_type_selector": {
       "options": {
         "BrowserMod": "BrowserMod",
         "Remote Assist Display": "Remote Assist Display",
         "Stream Assist": "Stream Assist"
-      }            
-    }        
-  }  
+      }
+    }
+  }
 }


### PR DESCRIPTION
OK, so quite a lot of code change but much of it is to help as you go forward.

- I have created constants for your config names and default values.  These are in const.py
- I have seperated your services into services.py, as it just makes things neater and will benefit as we create more services.
- There is a helper file (with 1 func atm) which ensures that the status_icons end up as a list and not a string from config.
- I have updated sensor.py to leverage this new runtime_data class and reduce code

Basically what is now happening is that config.runtime_data has attributes for all of the config data and options.  You will see this defined in the RuntimeData class defined in const.py

When HA starts these are set to the default values you see in the class definition.
As part of setup (line 68 in init.py) we iterate through all the config.data and config.option keys and set the RuntimeData attributes to these if they mathc on attribute name.

So, now you have all the set values and anything not set, is set to the default value.

Now, whenever you want to access or change any of these attributes you should use:
```
config.runtime_data.xxx
```
where xxx is the attribute name.  It is typed, so you should get the list of availabel attributes as you type.

I have also (as I was doing so much change in config_flow), fixed the deprecation warngin about setting self.config_entry.

As you were working in entity_listeners.py, I have not touched that but anywhere you are using
```
config_entry.options.get("XXX", "DEFAULT")
```
should now be changed to
```
config_entry.runtime_data.xxx
```
