### PR TITLE
Add websocket to get entity from browser id

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -8,6 +8,7 @@ from .entity_listeners import EntityListeners
 from .frontend import FrontendConfig
 from .helpers import ensure_list
 from .services import setup_services
+from .websocket import async_register_websockets
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,6 +37,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: VAConfigEntry):
 
     # Inisitialise service
     await setup_services(hass)
+
+    # Load websockets
+    await async_register_websockets(hass)
 
     return True
 

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -1,5 +1,10 @@
 """Helper functions."""
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .const import CONF_BROWSER_ID, DOMAIN
+
 
 def ensure_list(value: str | list[str]):
     """Ensure that a value is a list."""
@@ -9,3 +14,32 @@ def ensure_list(value: str | list[str]):
         value = (value.replace("[", "").replace("]", "").replace('"', "")).split(",")
         return value if value else []
     return []
+
+
+def get_entity_id_by_browser_id(hass: HomeAssistant, browser_id: str) -> str:
+    """Get entity id form browser id.
+
+    Support websocket
+    """
+    entity_registry = er.async_get(hass)
+
+    # Get all instances of view assist
+    entry_ids = [entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN)]
+
+    # For each instance, get list of entities
+    for entry_id in entry_ids:
+        integration_entities = er.async_entries_for_config_entry(
+            entity_registry, entry_id
+        )
+        # Get entity ids
+        entity_ids = [entity.entity_id for entity in integration_entities if entity]
+
+        # Get entity id state and check browser id attribute
+        for entity_id in entity_ids:
+            if state := hass.states.get(entity_id):
+                if (
+                    state.attributes.get(CONF_BROWSER_ID)
+                    and state.attributes[CONF_BROWSER_ID] == browser_id
+                ):
+                    return entity_id
+    return None

--- a/custom_components/view_assist/websocket.py
+++ b/custom_components/view_assist/websocket.py
@@ -1,0 +1,35 @@
+"""View Assist websocket handlers."""
+
+import voluptuous as vol
+
+from homeassistant.components.websocket_api import (
+    ActiveConnection,
+    async_register_command,
+    async_response,
+    websocket_command,
+)
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .helpers import get_entity_id_by_browser_id
+
+
+async def async_register_websockets(hass: HomeAssistant):
+    """Register websocket functions."""
+
+    # Get sensor entity by browser id
+    @websocket_command(
+        {
+            vol.Required("type"): f"{DOMAIN}/get_entity_id",
+            vol.Required("browser_id"): str,
+        }
+    )
+    @async_response
+    async def websocket_get_entity_by_browser_id(
+        hass: HomeAssistant, connection: ActiveConnection, msg: dict
+    ) -> None:
+        """Get entity id by browser id."""
+        output = get_entity_id_by_browser_id(hass, msg["browser_id"])
+        connection.send_result(msg["id"], output)
+
+    async_register_command(hass, websocket_get_entity_by_browser_id)


### PR DESCRIPTION
To use test, use js like this.

```
var_assistsat_entity: |-
        [[[
          try {
            hass.callWS({
              type: 'view_assist/get_entity_id',
              browser_id: localStorage.getItem("browser_mod-browser-id")
            }).then(response =>
            console.log("Entity is - ", response));
          } catch { return  ""}
        ]]]
```

I think to set var it is this but needs you to test.

```
var_assistsat_entity: |-
        [[[
          try {
            hass.callWS({
              type: 'view_assist/get_entity_id',
              browser_id: localStorage.getItem("browser_mod-browser-id")
            }).then(response =>
           return response));
          } catch { return  ""}
        ]]]
```