### PR TITLE
Add rotate display capability and fix get_random_image

### DIFF
--- a/custom_components/view_assist/services.yaml
+++ b/custom_components/view_assist/services.yaml
@@ -19,16 +19,18 @@ navigate:
       required: true
       selector:
         text:
-    display_type:
-      name: Display Type
-      description: The integration used to control the display
-      example: "BrowserMod"
-      required: true
+    revert:
+      name: Revert Display
+      description: Revert to home screen after display timeout - default is yes
+      required: false
       selector:
-        select:
-          options:
-            - "BrowserMod"
-            - "Remote Assist Display"
+        boolean:
+    timeout:
+      name: Timeout
+      description: Timeout to revert the screen in seconds
+      required: false
+      selector:
+        number:
 set_state:
   name: Set state or attributes
   description: >


### PR DESCRIPTION
So, done a few things for you tonight:

1. Added ability to not revert in browser_navigate.  NOTE: Also updated the navigate service to only now need device, path with option for revert and timeout.  Defaults for revert is yes, and timeout is view_timeout setting in config.
2. Added a function to roate the display.  See entity_services.py line 82 for function, example of use line 292
3. Fixed the service call for get_random_image.  Number of things I think were issues here but think main one was an async/sync issue.  I have moved the get image function into helpers.py and call this from the service call. You will see on line 286 of entity_listeners.py how to call a this sync function from async in code.