### PR TITLE
Register js module for view assist

### DIFF
--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -7,6 +7,13 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 
 DOMAIN = "view_assist"
+URL_BASE = "/view_assist"
+JSMODULES = [
+    {
+        "filename": "view_assist.js",
+        "version": "1.0.0",
+    },
+]
 
 type VAConfigEntry = ConfigEntry[RuntimeData]
 
@@ -222,7 +229,7 @@ class RuntimeData:
         self.status_icons_size: VAIconSizes = DEFAULT_STATUS_ICON_SIZE
         self.font_style: str = DEFAULT_FONT_STYLE
         self.status_icons: list[str] = DEFAULT_STATUS_ICONS
-        self.use_24h_time: bool = DEFAULT_USE_24H_TIME
+        self.use_24_hour_time: bool = DEFAULT_USE_24H_TIME
 
         # Default options
         self.weather_entity: str = DEFAULT_WEATHER_ENITITY

--- a/custom_components/view_assist/frontend.py
+++ b/custom_components/view_assist/frontend.py
@@ -59,7 +59,7 @@ class FrontendConfig:
 
         dc = dashboard.DashboardsCollection(self.hass)
         await dc.async_load()
-        dashboard_exists = any([e["url_path"] == self.path for e in dc.async_items()])
+        dashboard_exists = any(e["url_path"] == self.path for e in dc.async_items())
 
         if not dashboard_exists:
             # Create entry in dashboard collection
@@ -119,6 +119,7 @@ class FrontendConfig:
             ]
 
             # Iterate list of views to add
+            modified = False
             for view in views_to_load:
                 # If view already exists, skip adding it
                 if view in existing_views:
@@ -139,9 +140,11 @@ class FrontendConfig:
                 }
 
                 dashboard_config["views"].append(new_view)
+                modified = True
 
             # Save dashboard config back to HA
-            await dashboard_store.async_save(dashboard_config)
+            if modified:
+                await dashboard_store.async_save(dashboard_config)
 
     async def _delete_home_view(self):
         # Get lovelace (frontend) config data
@@ -155,10 +158,13 @@ class FrontendConfig:
             dashboard_config = await dashboard_store.async_load(True)
 
             # Remove view with title of home
+            modified = False
             for i, view in enumerate(dashboard_config["views"]):
                 if view.get("title", "").lower() == "home":
                     del dashboard_config["views"][i]
+                    modified = True
                     break
 
             # Save dashboard config back to HA
-            await dashboard_store.async_save(dashboard_config)
+            if modified:
+                await dashboard_store.async_save(dashboard_config)

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -35,6 +35,16 @@ def is_first_instance(
     return False
 
 
+def get_loaded_instance_count(hass: HomeAssistant) -> int:
+    """Return number of loaded instances."""
+    entries = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if not entry.disabled_by
+    ]
+    return len(entries)
+
+
 def ensure_list(value: str | list[str]):
     """Ensure that a value is a list."""
     if isinstance(value, list):

--- a/custom_components/view_assist/js_modules/__init__.py
+++ b/custom_components/view_assist/js_modules/__init__.py
@@ -1,0 +1,154 @@
+"""View Assist Javascript module registration."""
+
+import logging
+import os
+from pathlib import Path
+
+from homeassistant.components.http import StaticPathConfig
+from homeassistant.components.lovelace import LovelaceData
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.event import async_call_later
+
+from ..const import JSMODULES, URL_BASE  # noqa: TID252
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class JSModuleRegistration:
+    """Register Javascript modules."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialise."""
+        self.hass = hass
+        self.lovelace: LovelaceData = self.hass.data.get("lovelace")
+
+    async def async_register(self):
+        """Register view_assist path."""
+        await self._async_register_path()
+        if self.lovelace.mode == "storage":
+            await self._async_wait_for_lovelace_resources()
+
+    # install card resources
+    async def _async_register_path(self):
+        """Register resource path if not already registered."""
+        try:
+            await self.hass.http.async_register_static_paths(
+                [StaticPathConfig(URL_BASE, Path(__file__).parent, False)]
+            )
+            _LOGGER.debug("Registered resource path from %s", Path(__file__).parent)
+        except RuntimeError:
+            # Runtime error is likley this is already registered.
+            _LOGGER.debug("Resource path already registered")
+
+    async def _async_wait_for_lovelace_resources(self) -> None:
+        """Wait for lovelace resources to have loaded."""
+
+        async def _check_lovelace_resources_loaded(now):
+            if self.lovelace.resources.loaded:
+                await self._async_register_modules()
+            else:
+                _LOGGER.debug(
+                    "Unable to install resources because Lovelace resources have not yet loaded.  Trying again in 5 seconds"
+                )
+                async_call_later(self.hass, 5, _check_lovelace_resources_loaded)
+
+        await _check_lovelace_resources_loaded(0)
+
+    async def _async_register_modules(self):
+        """Register modules if not already registered."""
+        _LOGGER.debug("Installing javascript modules")
+
+        # Get resources already registered
+        resources = [
+            resource
+            for resource in self.lovelace.resources.async_items()
+            if resource["url"].startswith(URL_BASE)
+        ]
+
+        for module in JSMODULES:
+            url = f"{URL_BASE}/{module.get('filename')}"
+
+            card_registered = False
+
+            for resource in resources:
+                if self._get_resource_path(resource["url"]) == url:
+                    card_registered = True
+                    # check version
+                    if self._get_resource_version(resource["url"]) != module.get(
+                        "version"
+                    ):
+                        # Update card version
+                        _LOGGER.debug(
+                            "Updating %s to version %s",
+                            module.get("name"),
+                            module.get("version"),
+                        )
+                        await self.lovelace.resources.async_update_item(
+                            resource.get("id"),
+                            {
+                                "res_type": "module",
+                                "url": url + "?v=" + module.get("version"),
+                            },
+                        )
+                        # Remove old gzipped files
+                        await self.async_remove_gzip_files()
+                    else:
+                        _LOGGER.debug(
+                            "%s already registered as version %s",
+                            module.get("name"),
+                            module.get("version"),
+                        )
+
+            if not card_registered:
+                _LOGGER.debug(
+                    "Registering %s as version %s",
+                    module.get("name"),
+                    module.get("version"),
+                )
+                await self.lovelace.resources.async_create_item(
+                    {"res_type": "module", "url": url + "?v=" + module.get("version")}
+                )
+
+    def _get_resource_path(self, url: str):
+        return url.split("?")[0]
+
+    def _get_resource_version(self, url: str):
+        if version := url.split("?")[1].replace("v=", ""):
+            return version
+        return 0
+
+    async def async_unregister(self):
+        """Unload lovelace module resource."""
+        if self.hass.data["lovelace"]["mode"] == "storage":
+            for module in JSMODULES:
+                url = f"{URL_BASE}/{module.get('filename')}"
+                wiser_resources = [
+                    resource
+                    for resource in self.lovelace.resources.async_items()
+                    if str(resource["url"]).startswith(url)
+                ]
+                for resource in wiser_resources:
+                    await self.lovelace.resources.async_delete_item(resource.get("id"))
+
+    async def async_remove_gzip_files(self):
+        """Remove cached gzip files."""
+        await self.hass.async_add_executor_job(self.remove_gzip_files)
+
+    def remove_gzip_files(self):
+        """Remove cached gzip files."""
+        path = self.hass.config.path("custom_components/wiser/frontend")
+
+        gzip_files = [
+            filename for filename in os.listdir(path) if filename.endswith(".gz")
+        ]
+
+        for file in gzip_files:
+            try:
+                if (
+                    Path.stat(f"{path}/{file}").st_mtime
+                    < Path.stat(f"{path}/{file.replace('.gz', '')}").st_mtime
+                ):
+                    _LOGGER.debug("Removing older gzip file - %s", file)
+                    Path.unlink(f"{path}/{file}")
+            except OSError:
+                pass

--- a/custom_components/view_assist/js_modules/view_assist.js
+++ b/custom_components/view_assist/js_modules/view_assist.js
@@ -1,0 +1,38 @@
+export async function hass_base_el() {
+    await Promise.race([
+      customElements.whenDefined("home-assistant"),
+      customElements.whenDefined("hc-main"),
+    ]);
+
+    const element = customElements.get("home-assistant")
+      ? "home-assistant"
+      : "hc-main";
+
+    while (!document.querySelector(element))
+      await new Promise((r) => window.setTimeout(r, 100));
+    return document.querySelector(element);
+  }
+
+export async function provideHass() {
+const base = await hass_base_el();
+while (!base.hass) await new Promise((r) => window.setTimeout(r, 100));
+return base.hass;
+}
+
+const version = "1.0.0"
+const hass = await provideHass();
+
+// Get the view asssit entity for this browser id and save in local storage
+const va_entity = await hass.callWS({
+    type: 'view_assist/get_entity_id',
+    browser_id: localStorage.getItem("browser_mod-browser-id")
+})
+localStorage.setItem("view_assist_sensor", va_entity);
+
+// Output to console that this javascript is loaded
+console.info(
+    `%cVIEW ASSIST ${version} IS INSTALLED
+  %cView Assist Entity: ${va_entity}`,
+    "color: green; font-weight: bold",
+    ""
+  );

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -78,7 +78,7 @@ class ViewAssistSensor(SensorEntity):
             "status_icons_size": r.status_icons_size,
             "assist_prompt": r.assist_prompt,
             "font_style": r.font_style,
-            "use_24_hour_time": r.use_24h_time,
+            "use_24_hour_time": r.use_24_hour_time,
             "use_announce": r.use_announce,
             "background": r.background,
             "weather_entity": r.weather_entity,


### PR DESCRIPTION
In order to set the var_assistsat_entity on browser load, this change does the following:

1. Creates a javascript module to call the websocket service, passing in the localstorage stored browsermod browser_id and stores the result in local storage under view_assist_sensor.
2. Auto registers that module on load of HA.  I wrote this some time ago for my Drayton Wiser integration, so well tested in the wild!
3. Fixes a minor error in the naming of use_24_hour_time runtime variable, so that it does get picked up in the attributes (as it wasn't)

In order to now set the var_assistsat_entity value, just use

```
var_assistsat_entity: |-
        [[[
          return localStorage.getItem("view_assist_sensor")
        ]]]
```