### PR TITLE
Rework of navigate service

### DIFF
--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -15,6 +15,7 @@ JSMODULES = [
     },
 ]
 
+
 type VAConfigEntry = ConfigEntry[RuntimeData]
 
 
@@ -22,6 +23,20 @@ class VAMode(StrEnum):
     """View Assist modes."""
 
     NORMAL = "normal"
+    MUSIC = "music"
+    CYCLE = "cycle"
+    HOLD = "hold"
+    NIGHT = "night"
+    ROTATE = "rotate"
+
+
+VAMODE_REVERTS = {
+    VAMode.NORMAL: {"revert": True, "view": "home"},
+    VAMode.MUSIC: {"revert": True, "view": "music"},
+    VAMode.CYCLE: {"revert": False},
+    VAMode.HOLD: {"revert": True, "view": "_previous_view"},
+    VAMode.NIGHT: {"revert": True, "view": "home"},
+}
 
 
 class VAType(StrEnum):
@@ -209,6 +224,8 @@ class RuntimeData:
         """Initialise runtime data."""
         # Runtime variables go here
         self._timers = None
+        self._current_view: str | None = None
+        self._previous_view: str | None = None
 
         # Default config
         self.type: VAType | None = None

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -7,6 +7,8 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 
 DOMAIN = "view_assist"
+BROWSERMOD_DOMAIN = "browser_mod"
+REMOTE_ASSIST_DISPLAY_DOMAIN = "remote_assist_display"
 URL_BASE = "/view_assist"
 JSMODULES = [
     {
@@ -34,7 +36,7 @@ VAMODE_REVERTS = {
     VAMode.NORMAL: {"revert": True, "view": "home"},
     VAMode.MUSIC: {"revert": True, "view": "music"},
     VAMode.CYCLE: {"revert": False},
-    VAMode.HOLD: {"revert": True, "view": "_previous_view"},
+    VAMode.HOLD: {"revert": False},
     VAMode.NIGHT: {"revert": True, "view": "home"},
 }
 
@@ -224,8 +226,6 @@ class RuntimeData:
         """Initialise runtime data."""
         # Runtime variables go here
         self._timers = None
-        self._current_view: str | None = None
-        self._previous_view: str | None = None
 
         # Default config
         self.type: VAType | None = None

--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -1,23 +1,29 @@
 """Handles entity listeners."""
 
+import asyncio
+from asyncio import Task, TimerHandle
 import logging
 
-from homeassistant.const import CONF_DEVICE, CONF_MODE, CONF_PATH
+from homeassistant.const import CONF_MODE
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
-from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.event import async_track_state_change_event, partial
-from homeassistant.util import slugify
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
+from homeassistant.helpers.event import async_track_state_change_event
 
 from .const import (
+    BROWSERMOD_DOMAIN,
     CONF_DO_NOT_DISTURB,
     DOMAIN,
+    REMOTE_ASSIST_DISPLAY_DOMAIN,
     VA_ATTRIBUTE_UPDATE_EVENT,
     VAConfigEntry,
     VADisplayType,
     VAMode,
-    VAType,
 )
-from .helpers import get_random_image
+from .helpers import get_random_image, get_revert_settings_for_mode
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,34 +35,30 @@ class EntityListeners:
         """Initialise."""
         self.hass = hass
         self.config_entry = config_entry
+        self.browser_or_device_id: str | None = None
+
+        self.revert_view_task: Task | None = None
+        self.cycle_view_task: Task | None = None
 
         # Add microphone mute switch listener
         mic_device = config_entry.runtime_data.mic_device
         mic_type = config_entry.runtime_data.mic_type
         mute_switch = self.get_mute_switch(mic_device, mic_type)
 
+        # Add browser navigate service listener
+        config_entry.async_on_unload(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}_{config_entry.entry_id}_browser_navigate",
+                self._handle_browser_navigate_service_call,
+            )
+        )
+
         # Add listener to set_state service to call sensor_attribute_changed
         hass.bus.async_listen(
             VA_ATTRIBUTE_UPDATE_EVENT.format(config_entry.entry_id),
             self.async_set_state_changed_attribute,
         )
-
-        # Add listener for browsermod or remote assist display
-        if config_entry.runtime_data.type == VAType.VIEW_AUDIO:
-            if config_entry.runtime_data.display_type == VADisplayType.BROWSERMOD:
-                view_entity = f"sensor.{slugify(config_entry.runtime_data.browser_id)}_browser_path"
-            elif (
-                config_entry.runtime_data.display_type
-                == VADisplayType.REMOTE_ASSIST_DISPLAY
-            ):
-                # TODO: Change this to be correct sensor for RAD
-                view_entity = f"sensor.{slugify(config_entry.runtime_data.browser_id)}_browser_path"
-
-            config_entry.async_on_unload(
-                async_track_state_change_event(
-                    hass, view_entity, self._async_on_view_change
-                )
-            )
 
         # Add mic mute switch listener
         config_entry.async_on_unload(
@@ -72,69 +74,124 @@ class EntityListeners:
             )
         )
 
+    async def _display_revert_delay(self, path: str, timeout: int = 0):
+        """Display revert function.  To be called from task."""
+        if timeout:
+            await asyncio.sleep(timeout)
+            await self.async_browser_navigate(path, is_revert_action=True)
+
+    def _cancel_display_revert_task(self):
+        """Cancel any existing revert timer task."""
+        if self.revert_view_task and not self.revert_view_task.cancelled():
+            _LOGGER.info("Cancelled revert task")
+            self.revert_view_task.cancel()
+            self.revert_view_task = None
+
+    async def _handle_browser_navigate_service_call(self, args):
+        """Navigate browser to defined view.
+
+        Optionally revert to another view after timeout.
+        """
+        path = args["path"]
+        await self.async_browser_navigate(path)
+
+    async def async_browser_navigate(
+        self,
+        path: str,
+        is_revert_action: bool = False,
+    ):
+        """Navigate browser to defined view.
+
+        Optionally revert to another view after timeout.
+        """
+
+        # If new navigate before revert timer has expired, cancel revert timer.
+        if not is_revert_action:
+            self._cancel_display_revert_task()
+
+        # Do navigation and set revert if needed
+        display_type = self.config_entry.runtime_data.display_type
+        browser_id = self.config_entry.runtime_data.browser_id
+
+        _LOGGER.info(
+            "Navigating: %s, browser_id: %s, path: %s, display_type: %s, mode: %s",
+            self.config_entry.runtime_data.name,
+            browser_id,
+            path,
+            display_type,
+            self.config_entry.runtime_data.mode,
+        )
+
+        # If using BrowserMod
+        if display_type == VADisplayType.BROWSERMOD:
+            if not self.browser_or_device_id:
+                self.browser_or_device_id = browser_id
+
+            await self.hass.services.async_call(
+                BROWSERMOD_DOMAIN,
+                "navigate",
+                {"browser_id": self.browser_or_device_id, "path": path},
+            )
+
+        # If using RAD
+        elif display_type == VADisplayType.REMOTE_ASSIST_DISPLAY:
+            if not self.browser_or_device_id:
+                device_reg = dr.async_get(self.hass)
+                if device := device_reg.async_get_device(
+                    identifiers={(REMOTE_ASSIST_DISPLAY_DOMAIN, browser_id)}
+                ):
+                    self.browser_or_device_id = device.id
+            await self.hass.services.async_call(
+                REMOTE_ASSIST_DISPLAY_DOMAIN,
+                "navigate",
+                {"target": self.browser_or_device_id, "path": path},
+            )
+
+        # If this was a revert action, end here
+        if is_revert_action:
+            return
+
+        # Find required revert action
+        revert, revert_view = get_revert_settings_for_mode(
+            self.config_entry.runtime_data.mode
+        )
+        revert_path = (
+            getattr(self.config_entry.runtime_data, revert_view)
+            if revert_view
+            else None
+        )
+
+        # Set revert action if required
+        if revert and path != revert_path:
+            timeout = self.config_entry.runtime_data.view_timeout
+            _LOGGER.info("Adding revert to %s in %ss", revert_path, timeout)
+            self.revert_view_task = self.hass.async_create_task(
+                self._display_revert_delay(revert_path, timeout)
+            )
+
+    async def async_cycle_display_view(self, views: list[str]):
+        """Cycle display."""
+
+        view_index = 0
+        _LOGGER.info("Cycle display started")
+        while self.config_entry.runtime_data.mode == VAMode.CYCLE:
+            view_index = view_index % len(views)
+            _LOGGER.info("Cycling to view: %s", views[view_index])
+            await self.async_browser_navigate(
+                f"{self.config_entry.runtime_data.dashboard}/{views[view_index]}",
+            )
+            view_index += 1
+            await asyncio.sleep(self.config_entry.runtime_data.view_timeout)
+
     def update_entity(self):
         """Dispatch message that entity is listening for to update."""
         async_dispatcher_send(
             self.hass, f"{DOMAIN}_{self.config_entry.entry_id}_update"
         )
 
-    async def browser_navigate(self, path: str):
-        """Call browser navigate option."""
-
-        # Get entity id of VA entity
-        entity_id = f"sensor.{slugify(self.config_entry.runtime_data.name)}"
-
-        # Call our navigate service
-        await self.hass.services.async_call(
-            DOMAIN,
-            "navigate",
-            {
-                CONF_DEVICE: entity_id,
-                CONF_PATH: path,
-            },
-        )
-
-    async def cycle_display(self, views: list[str]):
-        """Cycle display."""
-
-        async def _interval_timer_expiry(view_index: int):
-            if self.config_entry.runtime_data.mode == VAMode.CYCLE:
-                # still in cycle mode
-                if view_index > (len(views) - 1):
-                    view_index = 0
-
-                # Navigate browser
-                await self.browser_navigate(
-                    f"{self.config_entry.runtime_data.dashboard}/{views[view_index]}",
-                )
-
-                # Set next timeout
-                self.hass.loop.call_later(
-                    timeout,
-                    partial(
-                        self.hass.create_task, _interval_timer_expiry(view_index + 1)
-                    ),
-                )
-            else:
-                _LOGGER.info("Cycle display terminated")
-
-        timeout = self.config_entry.runtime_data.view_timeout
-        await _interval_timer_expiry(0)
-        _LOGGER.info("Cycle display started")
-
     # ---------------------------------------------------------------------------------------
     # Actions for monitoring changes to external entities
     # ---------------------------------------------------------------------------------------
-
-    @callback
-    def _async_on_view_change(self, event: Event[EventStateChangedData]) -> None:
-        current_view = event.data["new_state"].state
-        previous_view = (
-            event.data["old_state"].state if event.data["old_state"] else None
-        )
-
-        # TODO: Decide when to save values to runtime_data._current_view and _previous_view for hold mode
-        # And then utilise these if navigate in that mode.
 
     @callback
     def _async_on_mic_change(self, event: Event[EventStateChangedData]) -> None:
@@ -268,14 +325,19 @@ class EntityListeners:
         self.config_entry.runtime_data.status_icons = status_icons
         self.update_entity()
 
+        if new_mode != VAMode.CYCLE:
+            if self.cycle_view_task and not self.cycle_view_task.cancelled():
+                self.cycle_view_task.cancel()
+                _LOGGER.info("Cycle display terminated")
+
         if new_mode == VAMode.NORMAL:
             # Add navigate to default view
-            await self.browser_navigate(self.config_entry.runtime_data.home)
+            await self.async_browser_navigate(self.config_entry.runtime_data.home)
             _LOGGER.info("NAVIGATE TO: %s", new_mode)
 
         elif new_mode == VAMode.MUSIC:
             # Add navigate to music view
-            await self.browser_navigate(self.config_entry.runtime_data.music)
+            await self.async_browser_navigate(self.config_entry.runtime_data.music)
 
             # --------------------------------------------
             # Service call option
@@ -293,10 +355,15 @@ class EntityListeners:
         elif new_mode == VAMode.CYCLE:
             # Add start cycle mode
             # Pull cycle_mode attribute
-            await self.cycle_display(
-                views=["music", "info", "weather", "clock"],
+            self.cycle_view_task = self.hass.async_create_task(
+                self.async_cycle_display_view(
+                    views=["music", "info", "weather", "clock"]
+                )
             )
             _LOGGER.info("START MODE: %s", new_mode)
+        elif new_mode == VAMode.HOLD:
+            # Hold mode, so cancel any revert timer
+            self._cancel_display_revert_task()
         elif new_mode == VAMode.ROTATE:
             #
             # Test image rotate service

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -9,7 +9,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import datetime
 
-from .const import CONF_BROWSER_ID, DOMAIN, VAConfigEntry, VAType
+from .const import (
+    CONF_BROWSER_ID,
+    DOMAIN,
+    VAMODE_REVERTS,
+    VAConfigEntry,
+    VAMode,
+    VAType,
+)
 
 
 def is_first_instance(
@@ -82,6 +89,13 @@ def get_entity_id_by_browser_id(hass: HomeAssistant, browser_id: str) -> str:
                 ):
                     return entity_id
     return None
+
+
+def get_revert_settings_for_mode(mode: VAMode) -> tuple:
+    """Get revert settings from VAMODE_REVERTS for mode."""
+    if mode in VAMODE_REVERTS:
+        return VAMODE_REVERTS[mode].get("revert"), VAMODE_REVERTS[mode].get("view")
+    return False, None
 
 
 # ----------------------------------------------------------------

--- a/custom_components/view_assist/services.py
+++ b/custom_components/view_assist/services.py
@@ -22,15 +22,14 @@ from homeassistant.helpers import entity_registry as er, selector
 from homeassistant.helpers.event import partial
 
 from .const import (
-    CONF_DISPLAY_DEVICE,
-    CONF_DISPLAY_TYPE,
     CONF_REMOVE_ALL,
     CONF_TIME,
     CONF_TIMER_ID,
     DOMAIN,
     VAConfigEntry,
+    VADisplayType,
 )
-from .helpers import get_random_image
+from .helpers import get_random_image, get_revert_settings_for_mode
 from .timers import VATimers, decode_time_sentence
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,8 +40,6 @@ NAVIGATE_SERVICE_SCHEMA = vol.Schema(
             selector.EntitySelectorConfig(integration=DOMAIN)
         ),
         vol.Required(CONF_PATH): str,
-        vol.Optional("revert", default=True): bool,
-        vol.Optional("timeout", default=0): int,
     }
 )
 
@@ -189,8 +186,6 @@ class VAServices:
 
         va_entity_id = call.data.get(CONF_DEVICE)
         path = call.data.get(CONF_PATH)
-        revert = call.data.get("revert", True)
-        timeout = call.data.get("timeout")
 
         # get config entry from entity id to allow access to browser_id parameter
         entity_registry = er.async_get(self.hass)
@@ -209,59 +204,69 @@ class VAServices:
                         self.navigate_task[browser_id].cancel()
                     del self.navigate_task[browser_id]
 
-                # TODO: Remove fixed revert path and make dynamic based on logic/settings/mode
                 await self.async_browser_navigate(
+                    entity_config_entry=entity_config_entry,
                     browser_id=browser_id,
                     path=path,
                     display_type=display_type,
-                    revert_path=entity_config_entry.runtime_data.home
-                    if revert
-                    else None,
-                    timeout=timeout
-                    if timeout
-                    else entity_config_entry.runtime_data.view_timeout,
                 )
 
     async def async_browser_navigate(
         self,
+        entity_config_entry: VAConfigEntry,
         browser_id: str,
         path: str,
         display_type: str = "BrowserMod",
-        revert_path: str | None = None,
-        timeout: int = 10,
+        do_not_revert: bool = False,
     ):
         """Navigate browser to defined view.
 
         Optionally revert to another view after timeout.
         """
-
         _LOGGER.info(
-            "Navigating: browser_id: %s, path: %s, display_type: %s",
+            "Navigating: browser_id: %s, path: %s, display_type: %s, mode: %s",
             browser_id,
             path,
             display_type,
+            entity_config_entry.runtime_data.mode,
         )
 
-        if display_type == "BrowserMod":
+        if display_type == VADisplayType.BROWSERMOD:
             await self.hass.services.async_call(
                 "browser_mod",
                 "navigate",
                 {"browser_id": browser_id, "path": path},
             )
-        elif display_type == "Remote Assist Display":
+        elif display_type == VADisplayType.REMOTE_ASSIST_DISPLAY:
             await self.hass.services.async_call(
                 "remote_assist_display",
                 "navigate",
                 {"target": browser_id, "path": path},
             )
 
-        if revert_path and timeout:
+        if do_not_revert:
+            return
+
+        revert, revert_view = get_revert_settings_for_mode(
+            entity_config_entry.runtime_data.mode
+        )
+
+        revert_path = (
+            getattr(entity_config_entry.runtime_data, revert_view)
+            if revert_view
+            else None
+        )
+
+        if revert and path != revert_path:
+            timeout = entity_config_entry.runtime_data.view_timeout
             _LOGGER.info("Adding revert to %s in %ss", revert_path, timeout)
             self.navigate_task[browser_id] = self.hass.loop.call_later(
                 timeout,
                 partial(
                     self.hass.create_task,
-                    self.async_browser_navigate(browser_id, revert_path, display_type),
+                    self.async_browser_navigate(
+                        entity_config_entry, browser_id, revert_path, display_type, True
+                    ),
                     f"Revert browser {browser_id}",
                 ),
             )

--- a/custom_components/view_assist/services.yaml
+++ b/custom_components/view_assist/services.yaml
@@ -19,18 +19,6 @@ navigate:
       required: true
       selector:
         text:
-    revert:
-      name: Revert Display
-      description: Revert to home screen after display timeout - default is yes
-      required: false
-      selector:
-        boolean:
-    timeout:
-      name: Timeout
-      description: Timeout to revert the screen in seconds
-      required: false
-      selector:
-        number:
 set_state:
   name: Set state or attributes
   description: >


### PR DESCRIPTION
OK, so what has changed...

1. In const.py there is a new constant VAMODE_REVERTS on line 33.  This is defining by mode whether it shoudl revert or not and to where.
2. The navigate service has changed again to remove all but the device and the path.  The browser_navigate function now looks up what should happen after navigating to the requested path and sets a revert and where to if necessary.
3. Quite a bit of rework on the functions to manage navigation.  The main functions are now in entity_listeners.py and no longer in service.py
3. In service.py is the navigation service which raises an event to the new navigate listener in entity_listeners, which kicks off all the magic.
4. To navigate to anywhere from code you now just need to path to navigate to and it will work out the reverts as below based on the config in const.py
5. The navigate service and internal function call now supports RAD and works, so long as you have the display_type set to RAD and the RAD browserid in the browserid config.  **This does not use display_device and we maybe can get rid of that.**
 
**Status**
- Normal mode reverts to home (as defined in config)
- Music mode reverts to music view (as defined in config)
- Cycle mode iterates the (currently fixed list) without any revert (as per VAMODE_REVERTS)
- Hold mode - cancels any outstanding revert
- Night mode - atm, navigates back to home (as per VAMODE_REVERTS)

If you want to create a new mode, you just need to add to VAMODE_REVERTS to set what happens in terms of reverts.
 