### PR TITLE
remove browser_id and device_type, add mimic device

### DIFF
--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -9,9 +9,11 @@ from homeassistant.config_entries import ConfigEntry
 DOMAIN = "view_assist"
 BROWSERMOD_DOMAIN = "browser_mod"
 REMOTE_ASSIST_DISPLAY_DOMAIN = "remote_assist_display"
+
 URL_BASE = "/view_assist"
 JSMODULES = [
     {
+        "name": "View Assist Helper",
         "filename": "view_assist.js",
         "version": "1.0.0",
     },
@@ -134,7 +136,6 @@ CONF_MIC_DEVICE = "mic_device"
 CONF_MEDIAPLAYER_DEVICE = "mediaplayer_device"
 CONF_MUSICPLAYER_DEVICE = "musicplayer_device"
 CONF_DISPLAY_DEVICE = "display_device"
-CONF_BROWSER_ID = "browser_id"
 CONF_DASHBOARD = "dashboard"
 CONF_HOME = "home"
 CONF_INTENT = "intent"
@@ -147,8 +148,6 @@ CONF_STATUS_ICONS = "status_icons"
 CONF_USE_24H_TIME = "use_24_hour_time"
 CONF_WEATHER_ENTITY = "weather_entity"
 CONF_MIC_TYPE = "mic_type"
-CONF_DISPLAY_TYPE = "display_type"
-CONF_DISPLAY_DEVICE = "display_device"
 CONF_VIEW_TIMEOUT = "view_timeout"
 CONF_DO_NOT_DISTURB = "do_not_disturb"
 CONF_USE_ANNOUNCE = "use_announce"
@@ -156,6 +155,7 @@ CONF_MIC_UNMUTE = "micunmute"
 CONF_TIME = "time"
 CONF_TIMER_ID = "timer_id"
 CONF_REMOVE_ALL = "remove_all"
+CONF_DEV_MIMIC = "dev_mimic"
 
 # Config default values
 DEFAULT_NAME = "View Assist"
@@ -172,7 +172,6 @@ DEFAULT_STATUS_ICONS = []
 DEFAULT_USE_24H_TIME = False
 DEFAULT_WEATHER_ENITITY = "weather.home"
 DEFAULT_MIC_TYPE = VAMicType.HA_VOICE_SATELLITE
-DEFAULT_DISPLAY_TYPE = VADisplayType.BROWSERMOD
 DEFAULT_MODE = "normal"
 DEFAULT_VIEW_TIMEOUT = 20
 DEFAULT_DND = False
@@ -234,7 +233,7 @@ class RuntimeData:
         self.mediaplayer_device: str = ""
         self.musicplayer_device: str = ""
         self.display_device: str = ""
-        self.browser_id: str = ""
+        self.dev_mimic: bool = False
 
         # Dashboard options
         self.dashboard: str = DEFAULT_DASHBOARD
@@ -251,7 +250,6 @@ class RuntimeData:
         # Default options
         self.weather_entity: str = DEFAULT_WEATHER_ENITITY
         self.mic_type: VAMicType = DEFAULT_MIC_TYPE
-        self.display_type: VADisplayType = DEFAULT_DISPLAY_TYPE
         self.mode: str = DEFAULT_MODE
         self.view_timeout: int = DEFAULT_VIEW_TIMEOUT
         self.do_not_disturb: bool = DEFAULT_DND

--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -1,7 +1,7 @@
 """Handles entity listeners."""
 
 import asyncio
-from asyncio import Task, TimerHandle
+from asyncio import Task
 import logging
 
 from homeassistant.const import CONF_MODE
@@ -23,7 +23,12 @@ from .const import (
     VADisplayType,
     VAMode,
 )
-from .helpers import get_random_image, get_revert_settings_for_mode
+from .helpers import (
+    get_device_name_from_id,
+    get_display_type_from_browser_id,
+    get_random_image,
+    get_revert_settings_for_mode,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -110,8 +115,10 @@ class EntityListeners:
             self._cancel_display_revert_task()
 
         # Do navigation and set revert if needed
-        display_type = self.config_entry.runtime_data.display_type
-        browser_id = self.config_entry.runtime_data.browser_id
+        browser_id = get_device_name_from_id(
+            self.hass, self.config_entry.runtime_data.display_device
+        )
+        display_type = get_display_type_from_browser_id(self.hass, browser_id)
 
         _LOGGER.info(
             "Navigating: %s, browser_id: %s, path: %s, display_type: %s, mode: %s",

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -83,14 +83,11 @@ class ViewAssistSensor(SensorEntity):
             "background": r.background,
             "weather_entity": r.weather_entity,
             "mic_type": r.mic_type,
-            "display_type": r.display_type,
         }
 
         # Only add these attributes if they exist
         if r.display_device:
             attrs["display_device"] = r.display_device
-        if r.browser_id:
-            attrs["browser_id"] = r.browser_id
 
         # Add extra_data attributes from runtime data
         attrs.update(self.config.runtime_data.extra_data)

--- a/custom_components/view_assist/translations/en.json
+++ b/custom_components/view_assist/translations/en.json
@@ -13,7 +13,7 @@
       "unknown": "Unexpected error"
     },
     "step": {
-      "init": {
+      "options": {
         "title": "Configure a View Assist device",
         "data": {
           "name": "name",
@@ -21,7 +21,15 @@
           "mediaplayer_device": "Media player device",
           "musicplayer_device": "Music player device",
           "display_device": "Display Device",
-          "browser_id": "Browser Id"
+          "dev_mimic": "Mimic for view development"
+        },
+        "data_description": {
+          "name": "The View Assist satellite name",
+          "mic_device": "The microphone device for this satellite",
+          "mediaplayer_device": "The media player device for this satellite",
+          "musicplayer_device": "The music player device for this satellite",
+          "display_device": "The display device for this satellite",
+          "dev_mimic": "Use this device for view development on another machine"
         }
       }
     }
@@ -46,7 +54,7 @@
           "mediaplayer_device": "Media player device",
           "musicplayer_device": "Music player device",
           "display_device": "Display Device",
-          "browser_id": "Browser Id"
+          "dev_mimic": "Mimic for view development"
         },
         "data_description": {
           "name": "The View Assist satellite name",
@@ -54,7 +62,7 @@
           "mediaplayer_device": "The media player device for this satellite",
           "musicplayer_device": "The music player device for this satellite",
           "display_device": "The display device for this satellite",
-          "browser_id": "The browser id for this satellite"
+          "dev_mimic": "Use this device for view development on another machine"
         }
       },
       "dashboard_options": {
@@ -89,7 +97,6 @@
         "data": {
           "weather_entity": "Weather entity to use for conditons display",
           "mic_type": "The integration handling microphone input",
-          "display_type": "The integration handling the display control",
           "mode": "Default Mode",
           "view_timeout": "View Timeout",
           "do_not_disturb": "Default state for do not disturb mode",

--- a/custom_components/view_assist/websocket.py
+++ b/custom_components/view_assist/websocket.py
@@ -10,7 +10,7 @@ from homeassistant.components.websocket_api import (
 )
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import DOMAIN, VAType
 from .helpers import get_entity_id_by_browser_id
 
 
@@ -29,7 +29,9 @@ async def async_register_websockets(hass: HomeAssistant):
         hass: HomeAssistant, connection: ActiveConnection, msg: dict
     ) -> None:
         """Get entity id by browser id."""
-        output = get_entity_id_by_browser_id(hass, msg["browser_id"])
+        output = get_entity_id_by_browser_id(
+            hass, msg["browser_id"], return_dev_flagged_if_unmatched=True
+        )
         connection.send_result(msg["id"], output)
 
     async_register_command(hass, websocket_get_entity_by_browser_id)


### PR DESCRIPTION
- This now uses the display device to find the browser ID, device type (browsermod or RAD) and navigate the screen.
- The websocket now returns the first device that is flagged as a Mimic for Dev device if it cannot find a VA device with the browser id passed to it.

NOTE: you will need to go into each instance and configure the core device configuration to set the display device.
