### PR TITLE
Add view_assist_entities template function

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -11,6 +11,7 @@ from .frontend import FrontendConfig
 from .helpers import ensure_list, get_loaded_instance_count, is_first_instance
 from .js_modules import JSModuleRegistration
 from .services import VAServices
+from .templates import setup_va_templates
 from .timers import VATimers
 from .websocket import async_register_websockets
 
@@ -65,6 +66,8 @@ async def run_if_first_instance(hass: HomeAssistant, entry: VAConfigEntry):
     # Load javascript modules
     jsloader = JSModuleRegistration(hass)
     await jsloader.async_register()
+
+    setup_va_templates(hass)
 
 
 async def run_if_first_display_instance(hass: HomeAssistant, entry: VAConfigEntry):

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -180,6 +180,30 @@ def get_revert_settings_for_mode(mode: VAMode) -> tuple:
     return False, None
 
 
+def get_entities_by_attr_filter(
+    hass: HomeAssistant, filter: dict[str, Any] | None = None
+) -> list[str]:
+    """Get the entity ids of devices not in dnd mode."""
+    matched_entities = []
+    entry_ids = [entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN)]
+    for entry_id in entry_ids:
+        entity_registry = er.async_get(hass)
+        entities = er.async_entries_for_config_entry(entity_registry, entry_id)
+        for entity in entities:
+            if filter:
+                if state := hass.states.get(entity.entity_id):
+                    for attr, value in filter.items():
+                        if state.attributes.get(attr) == value:
+                            add_entity = True
+                        else:
+                            add_entity = False
+                    if add_entity:
+                        matched_entities.append(entity.entity_id)
+            else:
+                matched_entities.append(entity.entity_id)
+    return matched_entities
+
+
 # ----------------------------------------------------------------
 # Images
 # ----------------------------------------------------------------

--- a/custom_components/view_assist/templates.py
+++ b/custom_components/view_assist/templates.py
@@ -1,0 +1,87 @@
+"""Adds template functions to HA."""
+
+from collections.abc import Callable
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.template import Template, TemplateEnvironment
+
+from .helpers import get_entities_by_attr_filter
+
+DEFAULT_UNAVAILABLE_STATES = [
+    "unknown",
+    "unavailable",
+    "",
+    None,
+]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_va_templates(hass: HomeAssistant) -> bool:
+    """Install template functions."""
+
+    def is_safe_callable(self: TemplateEnvironment, obj) -> bool:
+        return isinstance(
+            obj,
+            VAGetEntities,
+        ) or self.ct_original_is_safe_callable(obj)
+
+    def patch_environment(env: TemplateEnvironment) -> None:
+        env.globals["view_assist_entities"] = VAGetEntities(hass)
+
+    def patched_init(
+        self: TemplateEnvironment,
+        hass_param: HomeAssistant | None,
+        limited: bool | None = False,
+        strict: bool | None = False,
+        log_fn: Callable[[int, str], None] | None = None,
+    ) -> None:
+        self.ct_original__init__(hass_param, limited, strict, log_fn)
+        patch_environment(self)
+
+    if not hasattr(TemplateEnvironment, "ct_original__init__"):
+        TemplateEnvironment.ct_original__init__ = TemplateEnvironment.__init__
+        TemplateEnvironment.__init__ = patched_init
+
+    if not hasattr(TemplateEnvironment, "ct_original_is_safe_callable"):
+        TemplateEnvironment.ct_original_is_safe_callable = (
+            TemplateEnvironment.is_safe_callable
+        )
+        TemplateEnvironment.is_safe_callable = is_safe_callable
+
+    tpl = Template("", hass)
+    tpl._strict = False  # noqa: SLF001
+    tpl._limited = False  # noqa: SLF001
+    patch_environment(tpl._env)  # noqa: SLF001
+    tpl._strict = True  # noqa: SLF001
+    tpl._limited = False  # noqa: SLF001
+    patch_environment(tpl._env)  # noqa: SLF001
+
+    return True
+
+
+# Template functions
+class VAGetEntities:
+    """Get entities or attr by attr filter."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Init."""
+        self._hass = hass
+
+    def __call__(
+        self, filter: dict[str, Any] | None = None, attr: str | None = None
+    ) -> list[str]:
+        "Call."
+        entities = get_entities_by_attr_filter(self._hass, filter)
+        if attr:
+            return [
+                self._hass.states.get(entity).attributes.get(attr)
+                for entity in entities
+            ]
+        return entities
+
+    def __repr__(self) -> str:
+        """Print."""
+        return "<template VAHelper>"


### PR DESCRIPTION
## View Assist Template Function

**function name:** view_assist_entities
**description:** returns a list of view assist sensor entites
**params:**
- **filter** (optional) - a json list of attribute value filters in the form
- **attr** (optional) - the name of an attribute value to return instead of the entity id

Examples:
```
view_assist_entities()
view_assist_entities(filter={"type":"view_audio"})
view_assist_entities(filter={"type":"view_audio", "do_not_disturb": true})
view_assist_entities(view_assist_entities(filter={"type":"view_audio"}, attr="mode"))
```