### PR TITLE
Add alarm sounder service

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -5,6 +5,7 @@ import logging
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import HomeAssistant
 
+from .alarm_repeater import VAAlarmRepeater
 from .const import RuntimeData, VAConfigEntry
 from .entity_listeners import EntityListeners
 from .frontend import FrontendConfig
@@ -66,6 +67,8 @@ async def run_if_first_instance(hass: HomeAssistant, entry: VAConfigEntry):
     # Load javascript modules
     jsloader = JSModuleRegistration(hass)
     await jsloader.async_register()
+
+    entry.runtime_data._alarm_repeater = VAAlarmRepeater(hass, entry)  # noqa: SLF001
 
     setup_va_templates(hass)
 

--- a/custom_components/view_assist/alarm_repeater.py
+++ b/custom_components/view_assist/alarm_repeater.py
@@ -1,0 +1,187 @@
+"""Handlers alarm repeater."""
+
+import asyncio
+from dataclasses import dataclass
+import logging
+
+from config.custom_components.view_assist.const import BROWSERMOD_DOMAIN
+from homeassistant.components.media_player import MediaPlayerEntity, MediaType
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity, entity_registry as er
+from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
+from homeassistant.helpers.network import get_url
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PlayingMedia:
+    """Class to hold paused media."""
+
+    media_content_id: str
+    media_type: str = "music"
+    media_position: float = 0
+    volume: int = 0
+
+
+class VAAlarmRepeater:
+    """Class to handle announcing on media player with resume."""
+
+    def __init__(self, hass: HomeAssistant, config: ConfigEntry) -> None:
+        """Initialise."""
+        self.hass = hass
+        self.config = config
+
+        self.alarm_tasks: dict[str, asyncio.Task] = {}
+
+    def _get_entity_from_entity_id(self, entity_id: str):
+        """Get entity object from entity_id."""
+        domain = entity_id.partition(".")[0]
+        entity_comp: EntityComponent[entity.Entity] | None
+        entity_comp = self.hass.data.get(DATA_INSTANCES, {}).get(domain)
+        if entity_comp:
+            return entity_comp.get_entity(entity_id)
+        return None
+
+    def _get_integration_domain(self, entity_id: str) -> str | None:
+        """Get integration of entity id."""
+
+        entity_registry = er.async_get(self.hass)
+        _entity = entity_registry.async_get(entity_id)
+        if _entity:
+            return _entity.platform
+        return None
+
+    def get_currently_playing_media(
+        self, media_entity: MediaPlayerEntity
+    ) -> PlayingMedia | None:
+        """Try and get currently playing media."""
+
+        # If not playing then return None
+        # if media_entity.state != MediaPlayerState.PLAYING:
+        #    _LOGGER.warning("Not PLAYING! - %s", media_entity.state)
+        #    return None
+        data = None
+        # An integration may populate these properties - most don't seem to
+        if content_id := media_entity.media_content_id:
+            data = PlayingMedia(
+                media_content_id=content_id,
+                media_type=media_entity.media_content_type | "music",
+                media_position=media_entity.media_position,
+            )
+
+        media_integration = media_entity.platform.platform_name
+        _LOGGER.debug("MEDIA ENTITY PLATFORM: %s", media_integration)
+        # Browermod
+        if media_integration == BROWSERMOD_DOMAIN:
+            _data = media_entity._data  # noqa: SLF001
+            _LOGGER.debug("MEDIA ENTITY DATA: %s", _data)
+            return PlayingMedia(
+                media_content_id=_data["player"].get("src"),
+                media_type="music",
+                media_position=_data.get("player", {}).get("media_position", None),
+                volume=_data.get("player", {}).get("volume", 0),
+            )
+
+        # Music Assistant
+        if media_integration == "mass":
+            data = media_entity.mass
+        # HA Voice Satellite
+        elif media_integration == "esphome":
+            data = media_entity._entry_data  # noqa: SLF001
+        else:
+            data = None
+
+        _LOGGER.debug("MEDIA PLAYER DATA: %s", data)
+        return None
+
+    async def repeat_media(
+        self, entity_id: str, media_type: str, media_url: str, max_repeats: int = 0
+    ):
+        """Repeat playing media file."""
+        # Format media url
+
+        if not media_url.startswith("http"):
+            media_url = media_url.removeprefix("/")
+            media_url = f"{get_url(self.hass)}/{media_url}"
+
+        i = 1
+        while i <= max_repeats or not max_repeats:
+            await self.hass.services.async_call(
+                "media_player",
+                "play_media",
+                {
+                    "entity_id": entity_id,
+                    "media_content_type": "music",
+                    "media_content_id": media_url,
+                },
+            )
+            await asyncio.sleep(1)
+            i += 1
+
+    async def cancel_alarm_sound(self, entity_id: str | None = None):
+        """Cancel announcement."""
+        if entity_id:
+            entities = [entity_id]
+        else:
+            entities = list(self.alarm_tasks.keys())
+
+        for mp_entity_id in entities:
+            await self.hass.services.async_call(
+                "media_player", "media_stop", {"entity_id": mp_entity_id}
+            )
+            if (
+                self.alarm_tasks.get(mp_entity_id)
+                and not self.alarm_tasks[mp_entity_id].done()
+            ):
+                self.alarm_tasks[mp_entity_id].cancel()
+
+    async def alarm_sound(
+        self,
+        entity_id: str,
+        media_url: str,
+        media_type: MediaType = "music",
+        resume: bool = True,
+        max_repeats: int = 0,
+    ):
+        """Announce to media player and resume."""
+
+        # Get instance of media player
+        media_entity: MediaPlayerEntity
+        if media_entity := self._get_entity_from_entity_id(entity_id):
+            playing_media = self.get_currently_playing_media(media_entity)
+
+            # Sound alarm
+            self.alarm_tasks[entity_id] = self.config.async_create_background_task(
+                self.hass,
+                self.repeat_media(entity_id, media_type, media_url, max_repeats),
+                name=f"AlarmRepeat-{entity_id}",
+            )
+
+            # Wait for alarm media task to finish
+            while not self.alarm_tasks[entity_id].done():
+                await asyncio.sleep(0.2)
+
+            if resume and playing_media:
+                _LOGGER.debug("Resuming media: %s", playing_media)
+                await self.hass.services.async_call(
+                    "media_player",
+                    "play_media",
+                    {
+                        "entity_id": entity_id,
+                        "media_content_type": playing_media.media_type,
+                        "media_content_id": playing_media.media_content_id,
+                    },
+                )
+
+                if playing_media.media_position:
+                    await self.hass.services.async_call(
+                        "media_player",
+                        "media_seek",
+                        {
+                            "entity_id": entity_id,
+                            "seek_position": playing_media.media_position,
+                        },
+                    )
+        return {}

--- a/custom_components/view_assist/alarm_repeater.py
+++ b/custom_components/view_assist/alarm_repeater.py
@@ -3,14 +3,17 @@
 import asyncio
 from dataclasses import dataclass
 import logging
+import time
+from typing import Any
 
-from .const import BROWSERMOD_DOMAIN
 from homeassistant.components.media_player import MediaPlayerEntity, MediaType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity, entity_registry as er
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 from homeassistant.helpers.network import get_url
+
+from .const import BROWSERMOD_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,6 +26,8 @@ class PlayingMedia:
     media_type: str = "music"
     media_position: float = 0
     volume: int = 0
+    player: Any | None = None
+    queue: Any | None = None
 
 
 class VAAlarmRepeater:
@@ -63,38 +68,106 @@ class VAAlarmRepeater:
         #    _LOGGER.warning("Not PLAYING! - %s", media_entity.state)
         #    return None
         data = None
-        # An integration may populate these properties - most don't seem to
-        if content_id := media_entity.media_content_id:
-            data = PlayingMedia(
-                media_content_id=content_id,
-                media_type=media_entity.media_content_type | "music",
-                media_position=media_entity.media_position,
-            )
 
+        # Hook into integration data to get currently playing media
         media_integration = media_entity.platform.platform_name
+
         _LOGGER.debug("MEDIA ENTITY PLATFORM: %s", media_integration)
         # Browermod
         if media_integration == BROWSERMOD_DOMAIN:
             _data = media_entity._data  # noqa: SLF001
-            _LOGGER.debug("MEDIA ENTITY DATA: %s", _data)
-            return PlayingMedia(
+            data = PlayingMedia(
                 media_content_id=_data["player"].get("src"),
                 media_type="music",
                 media_position=_data.get("player", {}).get("media_position", None),
                 volume=_data.get("player", {}).get("volume", 0),
             )
-
-        # Music Assistant
-        if media_integration == "mass":
-            data = media_entity.mass
         # HA Voice Satellite
         elif media_integration == "esphome":
-            data = media_entity._entry_data  # noqa: SLF001
-        else:
-            data = None
+            _LOGGER.debug("MUSIC ASSISTANT DATA: %s", media_entity._entry_data)  # noqa: SLF001
+
+        # An integration may populate these properties - most don't seem to
+        elif content_id := media_entity.media_content_id:
+            data = PlayingMedia(
+                media_content_id=content_id,
+                media_type=media_entity.media_content_type or "music",
+                media_position=media_entity.media_position,
+            )
 
         _LOGGER.debug("MEDIA PLAYER DATA: %s", data)
-        return None
+        return data
+
+    async def wait_for_state(
+        self,
+        media_entity: MediaPlayerEntity,
+        data_var: str,
+        attribute: str,
+        wanted_state: Any,
+        timeout: float = 10.0,
+    ) -> None:
+        """Wait for an object attribute to reach the given state."""
+        start_timestamp = time.time()
+        _LOGGER.debug("Waiting for %s to reach state %s", attribute, wanted_state)
+        try:
+            async with asyncio.timeout(timeout):
+                while (
+                    getattr(getattr(media_entity, data_var), attribute) != wanted_state
+                ):
+                    await asyncio.sleep(0.2)
+
+        except TimeoutError:
+            _LOGGER.debug(
+                "%s did not reach state %s within the timeout of %s seconds",
+                attribute,
+                wanted_state,
+                timeout,
+            )
+        except Exception as ex:  # noqa: BLE001
+            _LOGGER.error("ERROR: %s", ex)
+
+        elapsed_time = round(time.time() - start_timestamp, 2)
+        _LOGGER.debug(
+            "%s reached state %s within %s seconds",
+            attribute,
+            wanted_state,
+            elapsed_time,
+        )
+
+    async def repeat_announce(
+        self,
+        integration: str,
+        media_entity: MediaPlayerEntity,
+        media_url: str,
+        max_repeats: int = 0,
+    ):
+        """Repeat announcement using announce methods."""
+        _LOGGER.debug("Using announce for alarm")
+
+        if media_url.startswith("/"):
+            media_url = media_url.removeprefix("/")
+            media_url = f"{get_url(self.hass)}/{media_url}"
+
+        if integration == "music_assistant":
+            i = 1
+            while i <= max_repeats or max_repeats == 0:
+                try:
+                    _LOGGER.debug("Announcing iteration %s", i)
+                    await self.hass.services.async_call(
+                        "music_assistant",
+                        "play_announcement",
+                        service_data={"url": media_url},
+                        target={"entity_id": "media_player.snapweb_client"},
+                    )
+                    await asyncio.sleep(1)
+                    await self.wait_for_state(
+                        media_entity, "player", "announcement_in_progress", False
+                    )
+                    await asyncio.sleep(1)
+                    i += 1
+                except Exception as ex:  # noqa: BLE001
+                    _LOGGER.error("ERROR: %s", ex)
+                    return
+            _LOGGER.debug("Announce ended")
 
     async def repeat_media(
         self, entity_id: str, media_type: str, media_url: str, max_repeats: int = 0
@@ -102,7 +175,7 @@ class VAAlarmRepeater:
         """Repeat playing media file."""
         # Format media url
 
-        if not media_url.startswith("http"):
+        if media_url.startswith("/"):
             media_url = media_url.removeprefix("/")
             media_url = f"{get_url(self.hass)}/{media_url}"
 
@@ -128,13 +201,13 @@ class VAAlarmRepeater:
             entities = list(self.alarm_tasks.keys())
 
         for mp_entity_id in entities:
-            await self.hass.services.async_call(
-                "media_player", "media_stop", {"entity_id": mp_entity_id}
-            )
             if (
                 self.alarm_tasks.get(mp_entity_id)
                 and not self.alarm_tasks[mp_entity_id].done()
             ):
+                await self.hass.services.async_call(
+                    "media_player", "media_stop", {"entity_id": mp_entity_id}
+                )
                 self.alarm_tasks[mp_entity_id].cancel()
 
     async def alarm_sound(
@@ -150,38 +223,47 @@ class VAAlarmRepeater:
         # Get instance of media player
         media_entity: MediaPlayerEntity
         if media_entity := self._get_entity_from_entity_id(entity_id):
-            playing_media = self.get_currently_playing_media(media_entity)
+            media_integration = media_entity.platform.platform_name
 
-            # Sound alarm
-            self.alarm_tasks[entity_id] = self.config.async_create_background_task(
-                self.hass,
-                self.repeat_media(entity_id, media_type, media_url, max_repeats),
-                name=f"AlarmRepeat-{entity_id}",
-            )
+            if media_integration == "music_assistant":
+                self.alarm_tasks[entity_id] = self.config.async_create_background_task(
+                    self.hass,
+                    self.repeat_announce(media_integration, media_entity, media_url, 3),
+                    name=f"AnnounceRepeat-{entity_id}",
+                )
+            else:
+                playing_media = self.get_currently_playing_media(media_entity)
 
-            # Wait for alarm media task to finish
-            while not self.alarm_tasks[entity_id].done():
-                await asyncio.sleep(0.2)
-
-            if resume and playing_media:
-                _LOGGER.debug("Resuming media: %s", playing_media)
-                await self.hass.services.async_call(
-                    "media_player",
-                    "play_media",
-                    {
-                        "entity_id": entity_id,
-                        "media_content_type": playing_media.media_type,
-                        "media_content_id": playing_media.media_content_id,
-                    },
+                # Sound alarm
+                self.alarm_tasks[entity_id] = self.config.async_create_background_task(
+                    self.hass,
+                    self.repeat_media(entity_id, media_type, media_url, max_repeats),
+                    name=f"AlarmRepeat-{entity_id}",
                 )
 
-                if playing_media.media_position:
+                # Wait for alarm media task to finish
+                while not self.alarm_tasks[entity_id].done():
+                    await asyncio.sleep(0.2)
+
+                if resume and playing_media:
+                    _LOGGER.debug("Resuming media: %s", playing_media)
                     await self.hass.services.async_call(
                         "media_player",
-                        "media_seek",
+                        "play_media",
                         {
                             "entity_id": entity_id,
-                            "seek_position": playing_media.media_position,
+                            "media_content_type": playing_media.media_type,
+                            "media_content_id": playing_media.media_content_id,
                         },
                     )
+
+                    if playing_media.media_position:
+                        await self.hass.services.async_call(
+                            "media_player",
+                            "media_seek",
+                            {
+                                "entity_id": entity_id,
+                                "seek_position": playing_media.media_position,
+                            },
+                        )
         return {}

--- a/custom_components/view_assist/alarm_repeater.py
+++ b/custom_components/view_assist/alarm_repeater.py
@@ -4,7 +4,7 @@ import asyncio
 from dataclasses import dataclass
 import logging
 
-from config.custom_components.view_assist.const import BROWSERMOD_DOMAIN
+from .const import BROWSERMOD_DOMAIN
 from homeassistant.components.media_player import MediaPlayerEntity, MediaType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/custom_components/view_assist/alarm_repeater.py
+++ b/custom_components/view_assist/alarm_repeater.py
@@ -192,10 +192,12 @@ class VAAlarmRepeater:
                         service_data={"url": media_url},
                         target={"entity_id": "media_player.snapweb_client"},
                     )
+                    # Wait for time for status to update
                     await asyncio.sleep(1)
                     await self.wait_for_state(
                         media_entity, "player", "announcement_in_progress", False
                     )
+                    # Added to try and keep playing media position
                     await asyncio.sleep(1)
                     i += 1
                 except Exception as ex:  # noqa: BLE001

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -225,6 +225,7 @@ class RuntimeData:
         """Initialise runtime data."""
         # Runtime variables go here
         self._timers = None
+        self._alarm_repeater = None
 
         # Default config
         self.type: VAType | None = None

--- a/custom_components/view_assist/services.yaml
+++ b/custom_components/view_assist/services.yaml
@@ -104,5 +104,41 @@ get_timers:
       required: false
       selector:
         text:
+sound_alarm:
+  name: "Sound alarm"
+  description: "Sound alarm on a media device with an attempt to restore any already playing media"
+  fields:
+    entity_id:
+      name: "Entity ID"
+      description: "The media player to play the alarm on"
+      required: true
+      selector:
+        entity:
+          domain:
+            - media_player
+    media_file:
+      name: "Media file"
+      description: "Media file to use for alarm"
+      required: true
+      selector:
+        text:
+    max_repeats:
+      name: "Max repeats"
+      description: "The maximun number of times to repeat the alarm media file"
+      required: false
+      selector:
+        number:
+cancel_sound_alarm:
+  name: "Cancel sound alarm"
+  description: "Cancel a sounding alarm"
+  fields:
+    entity_id:
+      name: "Entity ID"
+      description: "The media player to cancel the alarm on"
+      required: false
+      selector:
+        entity:
+          domain:
+            - media_player
 
 

--- a/custom_components/view_assist/timers.py
+++ b/custom_components/view_assist/timers.py
@@ -12,9 +12,6 @@ from typing import Any
 
 import wordtodigits
 
-from config.custom_components.view_assist.helpers import (
-    get_entity_id_from_conversation_device_id,
-)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
@@ -34,6 +31,7 @@ from .const import (
     TimerStatus,
     TimerTime,
 )
+from .helpers import get_entity_id_from_conversation_device_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -139,7 +137,7 @@ def calc_days_add(day: str, dt_now: dt.datetime) -> int:
     return 0
 
 
-def decode_time_sentence(sentence: str) -> dt.datetime | None:
+def decode_time_sentence(sentence: str) -> dt.datetime | None:  # noqa: C901
     """Convert senstence from assist into datetime.
 
     Sentence can be:
@@ -196,10 +194,7 @@ def decode_time_sentence(sentence: str) -> dt.datetime | None:
         # Get if day or special day in sentence
         # This is a second check incase first REGEX does not detect it.
         if day_text := re.findall(REGEX_DAYS, _sentence):
-            _LOGGER.info("DAY TEXT: %s", day_text)
             set_time[0] = day_text[0]
-
-        _LOGGER.info("TIME: %s -> %s", sentence, set_time)
 
         # make into a class object
         time_info = TimerTime(
@@ -216,8 +211,6 @@ def decode_time_sentence(sentence: str) -> dt.datetime | None:
     interval = int_search.groups()
 
     if any(interval):
-        _LOGGER.info("INTERVAL: %s -> %s", sentence, interval)
-
         interval = _convert_to_ints(list(interval))
 
         interval_info = TimerInterval(
@@ -232,14 +225,12 @@ def decode_time_sentence(sentence: str) -> dt.datetime | None:
     spec_time = re.findall(REGEX_SUPER_TIME, _sentence)
     if spec_time:
         set_time = list(spec_time[0])
-        _LOGGER.info("SUPER TEXT: %s -> %s", sentence, set_time)
 
         # return None if not a full match
         if all(set_time[1:3]):
             # Get if day or special day in sentence
             # This is a second check incase first REGEX does not detect it.
             if day_text := re.findall(REGEX_DAYS, _sentence):
-                _LOGGER.info("DAY TEXT: %s", day_text)
                 set_time[0] = day_text[0]
 
             # now iterate and replace text numbers with numbers
@@ -253,8 +244,6 @@ def decode_time_sentence(sentence: str) -> dt.datetime | None:
                 set_time[1] = int(set_time[1])
             if isinstance(set_time[3], str) and set_time[3].isnumeric():
                 set_time[3] = int(set_time[3])
-
-            _LOGGER.info("TRANSLATED: %s", set_time)
 
             # Amend for set_time[2] == "to"
             if set_time[2] == "to":
@@ -275,7 +264,6 @@ def decode_time_sentence(sentence: str) -> dt.datetime | None:
     interval = re.findall(REGEX_SUPER_INTERVAL, _sentence)
     if interval:
         interval = list(interval[0])
-        _LOGGER.info("INTERVAL: %s -> %s", sentence, interval)
 
         # Convert hours to numbers
         if interval[1] in HOURS:
@@ -302,7 +290,9 @@ def decode_time_sentence(sentence: str) -> dt.datetime | None:
         )
         return sentence, interval_info
 
-    _LOGGER.info("DECODE: NOT DECODED: %s -> %s", sentence, None)
+    _LOGGER.warning(
+        "Time senstence decoder - Unable to decode: %s -> %s", sentence, None
+    )
     return sentence, _sentence
 
 
@@ -343,7 +333,6 @@ def get_datetime_from_timer_time(
 
         if set_time.hour < 12 and set_datetime + dt.timedelta(hours=12) > dt_now:
             add_hours = 12
-            _LOGGER.info("CONTEXT TIME: Adding %sh", add_hours)
 
     # Now build datetime
     date = dt_now
@@ -357,12 +346,10 @@ def get_datetime_from_timer_time(
     # if day name in sentence
     if set_time.day:
         add_days = calc_days_add(set_time.day, dt_now)
-        _LOGGER.info("DAY INTERPRETATION: Adding %s days", add_days)
         date = date + dt.timedelta(days=add_days)
 
     # If time is less than now, add 1 day
     if date < dt.datetime.now():
-        _LOGGER.info("ADDING 1 DAY")
         date = date + dt.timedelta(days=1)
 
     return date
@@ -383,8 +370,8 @@ def encode_datetime_to_human(
         days, hours = divmod(hours, 24)
 
         response = []
-        _LOGGER.info(
-            "TIMER: %s days %s hours, %s mins, %s secs ", days, hours, minutes, seconds
+        _LOGGER.debug(
+            "Timer: %s days %s hours, %s mins, %s secs ", days, hours, minutes, seconds
         )
         if days:
             response.append(f"{days} days")
@@ -467,19 +454,14 @@ class VATimers:
         """Save data store."""
         await self._store.async_save(self.timers)
 
-    def make_unix_time(self, time_or_interval: TimerTime | TimerInterval) -> int:
-        """Return unix time from Time or Interval object."""
-        if isinstance(time_or_interval, TimerTime):
-            return
-
     def is_duplicate_timer(self, device_id: str, name: str, expires_at: int) -> bool:
         """Return if same timer already exists."""
 
         # Get timers for device_id
         existing_device_timers = [
             timer_id
-            for timer_id in self.timers
-            if self.timers[timer_id].device_id == device_id
+            for timer_id, timer in self.timers.items()
+            if timer.device_id == device_id
         ]
 
         if not existing_device_timers:
@@ -557,13 +539,14 @@ class VATimers:
         if total_seconds < 1:
             await self._timer_finished(timer_id)
         else:
-            self.timer_tasks[timer_id] = self.hass.async_create_background_task(
+            self.timer_tasks[timer_id] = self.config.async_create_background_task(
+                self.hass,
                 self._wait_for_timer(timer_id, total_seconds, timer.created_at),
                 name=f"Timer {timer_id}",
             )
             self.timers[timer_id].status = TimerStatus.RUNNING
             await self.save()
-            _LOGGER.info("STARTED %s TIMER FOR %s", timer.name, total_seconds)
+            _LOGGER.debug("Started %s timer for %s", timer.name, total_seconds)
 
     async def _wait_for_timer(
         self, timer_id: str, seconds: int, updated_at: int
@@ -599,9 +582,9 @@ class VATimers:
         if timer_ids:
             for timerid in timer_ids:
                 if self.timers.pop(timerid, None):
-                    _LOGGER.info("Cancelled timer: %s", timerid)
+                    _LOGGER.debug("Cancelled timer: %s", timerid)
                     if timer_task := self.timer_tasks.pop(timerid, None):
-                        if not timer_task.cancelled():
+                        if not timer_task.done():
                             timer_task.cancel()
             await self.save()
             return True
@@ -635,7 +618,7 @@ class VATimers:
 
         self.timer_tasks.pop(timer_id, None)
 
-        _LOGGER.info("TIMER EXPIRED: %s", timer)
+        _LOGGER.info("Timer expired: %s", timer)
 
         self.hass.bus.fire(
             VA_TIMER_FINISHED_EVENT,


### PR DESCRIPTION
OK, alarm service.

Tested with browsermod and music assistant media players.  Needs more testing and a solution for HA Voice Satellites.

## Services:

**Sound Alarm**
- entity_id: (required) media player device
- media file: (required) local file or url
- max_repeats: (optional) max times to repeat.  Leaving out or setting to 0, keeps repeating.
```
action: view_assist.sound_alarm
data:
  entity_id: media_player.b7141f1b_c14cba93
  media_file: /local/viewassist/alarm.mp3
  max_repeats: 10
```

**Cancel Sound Alarm**
- entity_id: (optional) media player device
```
action: view_assist.cancel_sound_alarm
data:
  entity_id: media_player.b7141f1b_c14cba93
```

NOTE: There maybe a bug in the cancel alarm (need to test more), so run without an entity id for now and it will cancel any running alarms.