### PR TITLE
amend timer expiry sentence

### DIFF
--- a/custom_components/view_assist/timers.py
+++ b/custom_components/view_assist/timers.py
@@ -153,28 +153,32 @@ class Timer:
         }
 
     @property
-    def dynamic_name(self) -> str:
+    def dynamic_remaining(self) -> str:
         """Generate dynamic name."""
         return encode_datetime_to_human(
             self.timer_type,
-            self.name,
             dt.datetime.fromtimestamp(self.expires_at),
-            append_name=False,
         )
 
     def to_dict(self) -> dict[str, Any]:
         """Return json output."""
+        dt_now = dt.datetime.now()
+        dt_expiry = dt.datetime.fromtimestamp(self.expires_at)
         return {
             "device_id": self.device_id,
             "timer_class": self.timer_class,
             "timer_type": self.timer_type,
             "name": self.name,
-            "expires": dt.datetime.fromtimestamp(self.expires_at),
+            "expires": dt_expiry,
             "original_expiry": dt.datetime.fromtimestamp(self.original_expires_at),
             "pre_expire_warning": self.pre_expire_warning,
-            "expires_in_seconds": math.ceil(self.expires_in_seconds),
-            "expires_in_interval": self.expires_in_interval,
-            "expires_in_text": self.dynamic_name,
+            "expiry": {
+                "seconds": math.ceil(self.expires_in_seconds),
+                "interval": self.expires_in_interval,
+                "expiry_day": get_named_day(dt_expiry, dt_now),
+                "expiry_time": get_formatted_time(dt_expiry),
+                "text": self.dynamic_remaining,
+            },
             "created_at": dt.datetime.fromtimestamp(self.created_at),
             "updated_at": dt.datetime.fromtimestamp(self.updated_at),
             "status": self.status,
@@ -502,14 +506,42 @@ def get_datetime_from_timer_time(
     return date
 
 
+def get_named_day(timer_dt: dt.datetime, dt_now: dt.datetime) -> str:
+    """Return a named day or date."""
+    days_diff = timer_dt.day - dt_now.day
+    if days_diff == 0:
+        return "Today"
+    if days_diff == 1:
+        return "Tomorrow"
+    if days_diff < 7:
+        return f"{WEEKDAYS[timer_dt.weekday()]}".title()
+    return timer_dt.strftime("%-d %B")
+
+
+def get_formatted_time(timer_dt: dt.datetime, h24format: bool = False) -> str:
+    """Format datetime to time."""
+
+    if h24format:
+        if timer_dt.second:
+            return timer_dt.strftime("%-H:%M:%S")
+        return timer_dt.strftime("%-H:%M")
+
+    if timer_dt.second:
+        return timer_dt.strftime("%-I:%M:%S %p")
+    return timer_dt.strftime("%-I:%M %p")
+
+
 def encode_datetime_to_human(
     timer_type: str,
-    timer_name: str,
     timer_dt: dt.datetime,
     h24format: bool = False,
-    append_name: bool = True,
 ) -> str:
     """Encode datetime into human speech sentence."""
+
+    def declension(term: str, qty: int) -> str:
+        if qty > 1:
+            return f"{term}s"
+        return term
 
     dt_now = dt.datetime.now()
     delta = timer_dt - dt_now
@@ -522,45 +554,29 @@ def encode_datetime_to_human(
 
         response = []
         if days:
-            response.append(f"{days} days")
+            response.append(f"{days} {declension('day', days)}")
         if hours:
-            response.append(f"{hours} hours")
+            response.append(f"{hours} {declension('hour', hours)}")
         if minutes:
-            response.append(f"{minutes} minutes")
+            response.append(f"{minutes} {declension('minute', minutes)}")
         if seconds:
-            response.append(f"{seconds} seconds")
+            response.append(f"{seconds} {declension('second', seconds)}")
 
-        duration = ", ".join(response)
-        if append_name and timer_name:
-            return f"{timer_name} in {duration}"
-        return duration
+        # Now create sentence
+        duration: str = ""
+        for i, entry in enumerate(response):
+            if i == len(response) - 1 and duration:
+                duration += " and " + entry
+            else:
+                duration += " " + entry
+
+        return duration.strip()
 
     if timer_type == "TimerTime":
         # do date bit - today, tomorrow, day of week if in next 7 days, date
-
-        days_diff = timer_dt.day - dt_now.day
-        named_output = True
-        if days_diff == 0:
-            output_date = "today"
-        elif days_diff == 1:
-            output_date = "tomorrow"
-        elif days_diff < 7:
-            output_date = f"{WEEKDAYS[timer_dt.weekday()]}"
-        else:
-            output_date = timer_dt.strftime("%-d %B")
-            named_output = False
-
-        if h24format:
-            output_time = timer_dt.strftime("%-H:%M")
-        else:
-            output_time = timer_dt.strftime("%-I:%M %p")
-
-        date_text = f"{output_date} at {output_time}"
-        if append_name and timer_name:
-            if named_output:
-                return f"{timer_name} for {date_text}"
-            return f"{timer_name} on {date_text}"
-        return date_text
+        output_date = get_named_day(timer_dt, dt_now)
+        output_time = get_formatted_time(timer_dt, h24format)
+        return f"{output_date} at {output_time}"
 
     return timer_dt
 
@@ -743,9 +759,7 @@ class VATimers:
             if start:
                 await self.start_timer(timer_id, timer)
 
-            encoded_time = encode_datetime_to_human(
-                timer_info_class, timer.name, expiry
-            )
+            encoded_time = encode_datetime_to_human(timer_info_class, expiry)
             return timer_id, timer.to_dict(), encoded_time
 
         return None, None, "already exists"
@@ -819,9 +833,7 @@ class VATimers:
             await self.start_timer(timer_id, timer)
             await self._fire_event(timer_id, TimerEvent.SNOOZED)
 
-            encoded_duration = encode_datetime_to_human(
-                "TimerInterval", timer.name, expiry
-            )
+            encoded_duration = encode_datetime_to_human("TimerInterval", expiry)
 
             return timer_id, timer.to_dict(), encoded_duration
         return None, None, "unable to snooze"
@@ -888,7 +900,7 @@ class VATimers:
             timers = [timer for timer in timers if timer["device_id"] == device_id]
 
         if sort and timers:
-            timers = sorted(timers, key=lambda d: d["expires_in_seconds"])
+            timers = sorted(timers, key=lambda d: d["expiry"]["seconds"])
 
         return timers
 

--- a/custom_components/view_assist/timers.py
+++ b/custom_components/view_assist/timers.py
@@ -175,8 +175,8 @@ class Timer:
             "expiry": {
                 "seconds": math.ceil(self.expires_in_seconds),
                 "interval": self.expires_in_interval,
-                "expiry_day": get_named_day(dt_expiry, dt_now),
-                "expiry_time": get_formatted_time(dt_expiry),
+                "day": get_named_day(dt_expiry, dt_now),
+                "time": get_formatted_time(dt_expiry),
                 "text": self.dynamic_remaining,
             },
             "created_at": dt.datetime.fromtimestamp(self.created_at),


### PR DESCRIPTION
Updated the expiry sentence as per discord chat.

Just to be as much of a PITA as possible for you......I have amended the strucutre of the timer to now have an expiry key and the various outputs under that as it was getting very messy.

So what was before

`expires_in_text` is now `expiry.text`

I have added a coupe more options (expiry.day and expiry.time, so you can see which are best to use on the dfferent views.

Like below:

```yaml
   - id: 01JMX6CQM007HD9FZ3J2XFBVFV
    device_id: 4a3389dfdc31e0c0fe451396ea741118
    timer_class: alarm
    timer_type: TimerTime
    name: ""
    expires: "2025-02-25T01:35:00"
    original_expiry: "2025-02-25T01:35:00"
    pre_expire_warning: 10
    expiry:
      seconds: 3702
      interval:
        days: 0
        hours: 1
        minutes: 1
        seconds: 42
      day: Today
      time: 1:35 AM
      text: Today at 1:35 AM
    created_at: "2025-02-24T23:59:02"
    updated_at: "2025-02-24T23:59:02"
    status: running
    extra_info:
      sentence: tomorrow at 1:35 am
      timer_info:
        day: tomorrow
        hour: 1
        minute: 35
        second: 0
        meridiem: am
      view_assist_entity_id: sensor.display_test
  - id: 01JMX57QTM4EMVC484SJ62KEWY
    device_id: 4a3389dfdc31e0c0fe451396ea741118
    timer_class: timer
    timer_type: TimerInterval
    name: ""
    expires: "2025-02-25T01:39:50"
    original_expiry: "2025-02-25T01:39:50"
    pre_expire_warning: 10
    expiry:
      seconds: 3992
      interval:
        days: 0
        hours: 1
        minutes: 6
        seconds: 32
      day: Today
      time: 1:39:50 AM
      text: 1 hour 6 minutes and 32 seconds
    created_at: "2025-02-24T23:38:50"
    updated_at: "2025-02-24T23:38:50"
    status: running
    extra_info:
      sentence: 2 hours and 1 minute
      timer_info:
        days: 0
        hours: 2
        minutes: 1
        seconds: 0
      view_assist_entity_id: sensor.display_test
```