### PR TITLE
Timer rework to use entity_id

### DIFF
--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import voluptuous as vol
 
-from .helpers import get_device_id_from_entity_id
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
@@ -15,6 +14,7 @@ from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import DOMAIN, VA_ATTRIBUTE_UPDATE_EVENT, VAConfigEntry
+from .helpers import get_device_id_from_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,6 +81,7 @@ class ViewAssistSensor(SensorEntity):
         attrs = {
             "type": r.type,
             "mic_device": r.mic_device,
+            "mic_device_id": get_device_id_from_entity_id(self.hass, r.mic_device),
             "mediaplayer_device": r.mediaplayer_device,
             "musicplayer_device": r.musicplayer_device,
             "mode": r.mode,
@@ -107,7 +108,7 @@ class ViewAssistSensor(SensorEntity):
 
         # display timers
         attrs["timers"] = self.hass.data[DOMAIN]["timers"].get_timers(
-            device_id=self._voice_device_id, include_expired=True
+            device_or_entity_id=self.entity_id, include_expired=True
         )
 
         return attrs

--- a/custom_components/view_assist/services.yaml
+++ b/custom_components/view_assist/services.yaml
@@ -38,12 +38,21 @@ set_timer:
   name: Set a timer
   description: Set an alarm, timer or reminder
   fields:
+    entity_id:
+      name: "Entity ID"
+      description: "Entity id of the View Assist entity"
+      required: false
+      selector:
+        entity:
+          integration: view_assist
+          domain:
+            - sensor
     device_id:
       name: "Device ID"
       description: "Device id of the voice satellite"
-      required: true
+      required: false
       selector:
-        text:
+        device:
     type:
       name: "Timer type"
       description: "The type of timer - alarm, timer, reminder, command"
@@ -77,12 +86,21 @@ cancel_timer:
       required: false
       selector:
         text:
+    entity_id:
+      name: "Entity ID"
+      description: "Entity id of the View Assist entity"
+      required: false
+      selector:
+        entity:
+          integration: view_assist
+          domain:
+            - sensor
     device_id:
       name: "Device ID"
       description: "The id of the voice satellite device to cancel all timers for"
       required: false
       selector:
-        text:
+        device:
     remove_all:
       name: "Remove all"
       description: "Cancel all timers"
@@ -99,12 +117,21 @@ get_timers:
       required: false
       selector:
         text:
+    entity_id:
+      name: "Entity ID"
+      description: "Entity id of the View Assist entity"
+      required: false
+      selector:
+        entity:
+          integration: view_assist
+          domain:
+            - sensor
     device_id:
       name: "Device ID"
       description: "The id of the voice satellite device to get all timers for"
       required: false
       selector:
-        text:
+        device:
 sound_alarm:
   name: "Sound alarm"
   description: "Sound alarm on a media device with an attempt to restore any already playing media"

--- a/custom_components/view_assist/templates.py
+++ b/custom_components/view_assist/templates.py
@@ -7,7 +7,12 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.template import Template, TemplateEnvironment
 
-from .helpers import get_entities_by_attr_filter
+from .helpers import (
+    get_config_entry_by_config_data_value,
+    get_entities_by_attr_filter,
+    get_mimic_entity_id,
+    get_sensor_entity_from_instance,
+)
 
 DEFAULT_UNAVAILABLE_STATES = [
     "unknown",
@@ -25,11 +30,12 @@ def setup_va_templates(hass: HomeAssistant) -> bool:
     def is_safe_callable(self: TemplateEnvironment, obj) -> bool:
         return isinstance(
             obj,
-            VAGetEntities,
+            (ViewAssistEntities, ViewAssistEntity),
         ) or self.ct_original_is_safe_callable(obj)
 
     def patch_environment(env: TemplateEnvironment) -> None:
-        env.globals["view_assist_entities"] = VAGetEntities(hass)
+        env.globals["view_assist_entities"] = ViewAssistEntities(hass)
+        env.globals["view_assist_entity"] = ViewAssistEntity(hass)
 
     def patched_init(
         self: TemplateEnvironment,
@@ -63,7 +69,7 @@ def setup_va_templates(hass: HomeAssistant) -> bool:
 
 
 # Template functions
-class VAGetEntities:
+class ViewAssistEntities:
     """Get entities or attr by attr filter."""
 
     def __init__(self, hass: HomeAssistant) -> None:
@@ -84,4 +90,25 @@ class VAGetEntities:
 
     def __repr__(self) -> str:
         """Print."""
-        return "<template VAHelper>"
+        return "<template ViewAssistEntities>"
+
+
+class ViewAssistEntity:
+    """Gets a va entity id from the passed entity id or device id that matches any of theconfigured mic, mediaplyer, music player or display device."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Init."""
+        self._hass = hass
+
+    def __call__(self, param: str, mimic: bool = False) -> list[str]:
+        "Call."
+
+        if entry := get_config_entry_by_config_data_value(self._hass, param):
+            return get_sensor_entity_from_instance(self._hass, entry.entry_id)
+        if mimic:
+            return get_mimic_entity_id(self._hass)
+        return None
+
+    def __repr__(self) -> str:
+        """Print."""
+        return "<template ViewAssistEntity>"

--- a/custom_components/view_assist/websocket.py
+++ b/custom_components/view_assist/websocket.py
@@ -10,8 +10,8 @@ from homeassistant.components.websocket_api import (
 )
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, VAType
-from .helpers import get_entity_id_by_browser_id
+from .const import DOMAIN
+from .helpers import get_entity_id_by_browser_id, get_mimic_entity_id
 
 
 async def async_register_websockets(hass: HomeAssistant):
@@ -29,9 +29,10 @@ async def async_register_websockets(hass: HomeAssistant):
         hass: HomeAssistant, connection: ActiveConnection, msg: dict
     ) -> None:
         """Get entity id by browser id."""
-        output = get_entity_id_by_browser_id(
-            hass, msg["browser_id"], return_dev_flagged_if_unmatched=True
-        )
+        output = get_entity_id_by_browser_id(hass, msg["browser_id"])
+        if not output:
+            output = get_mimic_entity_id(hass)
+
         connection.send_result(msg["id"], output)
 
     async_register_command(hass, websocket_get_entity_by_browser_id)


### PR DESCRIPTION
So changes in this PR.

## Timers
1. Timers are now stored by entity id instead of conversation device id.
2. Any existing timers should be updated - if this errors delete ./storage/view_assist.timers
3. When adding a timer via text assist, it will use the first mimic device set.  If none set it will error.

## Templates
1. The va_entities function is now called `view_assist_entities`
2. There is a new template function `view_assist_entity` which will take a string and return a VA entity id for any match to:
    - mic entity_id or device_id
    - mediaplayer entity_id or device_id
    - musicplayer - entity_id or device_id
    - display device_id
   
    If no match but the parameter `mimic=true` is set, it will return the mimic entity_id