### PR TITLE
Set url paths and load default views

### DIFF
--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 DOMAIN = "view_assist"
 BROWSERMOD_DOMAIN = "browser_mod"
 REMOTE_ASSIST_DISPLAY_DOMAIN = "remote_assist_display"
-
+VA_SUB_DIRS = ["backgrounds", "views", "audio", "images"]
 URL_BASE = "/view_assist"
 JSMODULES = [
     {

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from pathlib import Path
 import random
 from typing import Any
 
@@ -370,3 +371,19 @@ def get_random_image(
 
     # Return the image path in a dictionary
     return {"image_path": image_path}
+
+
+def create_dir_if_not_exist(hass: HomeAssistant, dir_name: str) -> bool:
+    """Create a directory under config if it doesn't exist.
+
+    Needs to be called from the executor to prevent blocking.
+    """
+    config_dir = hass.config.config_dir
+    path = Path(f"{config_dir}/{dir_name}")
+    try:
+        if not Path.exists(path):
+            Path.mkdir(path)
+            return True
+    except OSError:
+        return False
+    return False

--- a/custom_components/view_assist/services.py
+++ b/custom_components/view_assist/services.py
@@ -314,11 +314,8 @@ class VAServices:
         extra_data = call.data.get(CONF_EXTRA)
 
         sentence, timer_info = decode_time_sentence(timer_time)
-        _LOGGER.debug("ENTITY: %s, DEVICE: %s", entity_id, device_id)
-
         if entity_id is None and device_id is None:
             mimic_device = get_mimic_entity_id(self.hass)
-            _LOGGER.debug("MIMIC DEVICE: %s", mimic_device)
             if mimic_device:
                 entity_id = mimic_device
                 _LOGGER.warning(


### PR DESCRIPTION
As per discord

## Directories

- creates a view_assist directory under config with subdirs of audio, backgrounds, images, views

## URL Paths

- creates /view_assist/js pointing to js_modules folder for our view_assist.js module
- creates /view_assist/default pointing to the default_config folder
- creates /view_assist pointing to the config/view_assist folder

## Views

Any view is default_config/views will be loaded if a view with the same name does not already exist.  Previously this was am array list in the file for testing purposes.

## Dashboard

Functionality is the same as before.  If it does not exist, it will be created from the dashboard.yaml file in the default_config folder.