### PR TITLE
New feature: link device background to another VA device

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -5,6 +5,7 @@ import logging
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.start import async_at_started
 
 from .alarm_repeater import ALARMS, VAAlarmRepeater
 from .const import DOMAIN, RuntimeData, VAConfigEntry
@@ -99,10 +100,7 @@ async def run_if_first_display_instance(hass: HomeAssistant, entry: VAConfigEntr
         hass.data[DOMAIN][DASHBOARD_MANAGER] = dm
         await dm.setup_dashboard()
 
-    if hass.is_running:
-        await setup_frontend()
-    else:
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, setup_frontend)
+    async_at_started(hass, setup_frontend)
 
 
 def set_runtime_data_from_config(config_entry: VAConfigEntry):

--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -42,6 +42,7 @@ from .const import (
     CONF_MUSICPLAYER_DEVICE,
     CONF_ROTATE_BACKGROUND,
     CONF_ROTATE_BACKGROUND_INTERVAL,
+    CONF_ROTATE_BACKGROUND_LINKED_ENTITY,
     CONF_ROTATE_BACKGROUND_PATH,
     CONF_ROTATE_BACKGROUND_SOURCE,
     CONF_STATUS_ICON_SIZE,
@@ -82,6 +83,7 @@ from .const import (
     VAMicType,
     VAType,
 )
+from .helpers import get_sensor_entity_from_instance
 
 BASE_SCHEMA = {
     vol.Required(CONF_NAME): str,
@@ -96,7 +98,7 @@ BASE_SCHEMA = {
     ),
     # vol.Optional(CONF_INTENT_DEVICE): EntitySelector(
     #     EntitySelectorConfig(domain=SENSOR_DOMAIN)
-    # ),    
+    # ),
 }
 
 DISPLAY_SCHEMA = {
@@ -190,7 +192,7 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
         # Display reconfigure form if audio only
 
         # Also need to be in strings.json and translation files.
-        self.va_type = self.config_entry.data[CONF_TYPE]
+        self.va_type = self.config_entry.data[CONF_TYPE]  # pylint: disable=attribute-defined-outside-init
 
         if self.va_type == VAType.VIEW_AUDIO:
             return self.async_show_menu(
@@ -229,7 +231,7 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
             # vol.Optional(
             #     CONF_INTENT_DEVICE,
             #     default=self.config_entry.data.get(CONF_INTENT_DEVICE),
-            # ): EntitySelector(EntitySelectorConfig(domain=SENSOR_DOMAIN)),            
+            # ): EntitySelector(EntitySelectorConfig(domain=SENSOR_DOMAIN)),
         }
 
         if self.va_type == VAType.VIEW_AUDIO:
@@ -319,6 +321,7 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
                             "local_sequence",
                             "local_random",
                             "download",
+                            "link_to_entity",
                         ],
                         mode=SelectSelectorMode.LIST,
                     )
@@ -330,6 +333,22 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
                         DEFAULT_ROTATE_BACKGROUND_PATH,
                     ),
                 ): str,
+                vol.Optional(
+                    CONF_ROTATE_BACKGROUND_LINKED_ENTITY,
+                    default=self.config_entry.options.get(
+                        CONF_ROTATE_BACKGROUND_LINKED_ENTITY, vol.UNDEFINED
+                    ),
+                ): EntitySelector(
+                    EntitySelectorConfig(
+                        integration=DOMAIN,
+                        domain=SENSOR_DOMAIN,
+                        exclude_entities=[
+                            get_sensor_entity_from_instance(
+                                self.hass, self.config_entry.entry_id
+                            )
+                        ],
+                    )
+                ),
                 vol.Optional(
                     CONF_ROTATE_BACKGROUND_INTERVAL,
                     default=self.config_entry.options.get(

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -139,6 +139,7 @@ CONF_HIDE_SIDEBAR = "hide_sidebar"
 CONF_ROTATE_BACKGROUND = "rotate_background"
 CONF_ROTATE_BACKGROUND_SOURCE = "rotate_background_source"
 CONF_ROTATE_BACKGROUND_PATH = "rotate_background_path"
+CONF_ROTATE_BACKGROUND_LINKED_ENTITY = "rotate_background_linked_entity"
 CONF_ROTATE_BACKGROUND_INTERVAL = "rotate_background_interval"
 
 # Config default values
@@ -188,6 +189,7 @@ ATTR_RESUME_MEDIA = "resume_media"
 ATTR_MAX_REPEATS = "max_repeats"
 
 VA_ATTRIBUTE_UPDATE_EVENT = "va_attr_update_event_{}"
+VA_BACKGROUND_UPDATE_EVENT = "va_background_update_{}"
 
 
 class RuntimeData:
@@ -215,6 +217,7 @@ class RuntimeData:
         self.rotate_background: bool = False
         self.rotate_background_source: str = "local"
         self.rotate_background_path: str = ""
+        self.rotate_background_linked_entity: str = ""
         self.rotate_background_interval: int = 60
         self.assist_prompt: VAAssistPrompt = DEFAULT_ASSIST_PROMPT
         self.status_icons_size: VAIconSizes = DEFAULT_STATUS_ICON_SIZE

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -13,7 +13,12 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DOMAIN, VA_ATTRIBUTE_UPDATE_EVENT, VAConfigEntry
+from .const import (
+    DOMAIN,
+    VA_ATTRIBUTE_UPDATE_EVENT,
+    VA_BACKGROUND_UPDATE_EVENT,
+    VAConfigEntry,
+)
 from .helpers import get_device_id_from_entity_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -136,6 +141,12 @@ class ViewAssistSensor(SensorEntity):
                 self.hass.bus.fire(
                     VA_ATTRIBUTE_UPDATE_EVENT.format(self.config.entry_id), kwargs
                 )
+
+                # Fire background changed event to support linking device backgrounds
+                if k == "background":
+                    self.hass.bus.fire(
+                        VA_BACKGROUND_UPDATE_EVENT.format(self.entity_id), kwargs
+                    )
 
             # Set the value of named vartiables or add/update to extra_data dict
             if hasattr(self.config.runtime_data, k):

--- a/custom_components/view_assist/translations/en.json
+++ b/custom_components/view_assist/translations/en.json
@@ -81,6 +81,7 @@
           "rotate_background": "Enable image rotation",
           "rotate_background_source": "Image source",
           "rotate_background_path": "Image path",
+          "rotate_background_linked_entity": "Linked entity",
           "rotate_background_interval": "Rotation interval",
           "assist_prompt": "Assist prompt",
           "status_icons_size": "Status icon size",
@@ -96,7 +97,8 @@
           "music": "The view to return to when in music mode",
           "intent": "The view to display for default HA actions for displaying those entities",
           "background": "The default background image url",
-          "rotate_background_path": "Load images from in local mode and save to if in download mode.  A path under config/view_assist",
+          "rotate_background_path": "Load images from in local mode, save images to in download mode, ignored in linked mode.  A path under config/view_assist",
+          "rotate_background_linked_entity": "View Assist entity to link the background to",
           "rotate_background_interval": "Interval in minutes to rotate the background",
           "assist_prompt": "The Assist notification prompt style to use for wake word detection and intent processing",
           "status_icons_size": "Size of the icons in the status icon display",
@@ -167,7 +169,8 @@
       "options": {
         "local_sequence": "Local file path sequence",
         "local_random": "Local file path random",
-        "download": "Download random image from Unsplash"
+        "download": "Download random image from Unsplash",
+        "link_to_entity": "Linked to another View Assist device"
       }
     }
   }


### PR DESCRIPTION
This adds another option in the rotate background config to link the background to another VA device.

When linked, it listens for changes to the 'linked to' devices background and sets its own background to the same url.  
This works to keep in sync for any other rotation mode on the linked to device.