### PR TITLE
Add master config

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.start import async_at_started
@@ -19,6 +19,7 @@ from .helpers import (
 )
 from .http import HTTPManager
 from .js_modules import JSModuleRegistration
+from .master_config import MASTER_CONFIG, MasterConfigManager
 from .services import VAServices
 from .templates import setup_va_templates
 from .timers import TIMERS, VATimers
@@ -69,6 +70,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: VAConfigEntry):
 
 async def run_if_first_instance(hass: HomeAssistant, entry: VAConfigEntry):
     """Things to run only for first instance of integration."""
+    master_config = MasterConfigManager(hass, entry)
+    hass.data[DOMAIN][MASTER_CONFIG] = master_config
+    await master_config.load()
 
     # Inisitialise service
     services = VAServices(hass, entry)

--- a/custom_components/view_assist/master_config.py
+++ b/custom_components/view_assist/master_config.py
@@ -1,0 +1,69 @@
+"""Holds master config for View Assist."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN, VAConfigEntry
+
+MASTER_CONFIG = "master_config"
+
+
+@dataclass
+class MasterConfig:
+    """Class to hold master config."""
+
+    show_date: bool = False
+
+
+class MasterConfigManager:
+    """Class to manager master config."""
+
+    def __init__(self, hass: HomeAssistant, config: VAConfigEntry) -> None:
+        """Initialise."""
+        self._hass = hass
+        self._config = config
+        self._store = Store(hass, 1, f"{DOMAIN}.master_config")
+        self.config: MasterConfig
+
+        hass.services.async_register(
+            DOMAIN,
+            "set_master_config",
+            self._async_handle_set_master_config,
+        )
+
+    async def load(self):
+        """Load tiers from store."""
+        stored: dict[str, Any] = await self._store.async_load()
+        if stored:
+            self.config = MasterConfig(**stored)
+        else:
+            self.config = MasterConfig()
+
+    async def save(self):
+        """Save store."""
+        await self._store.async_save(self.config)
+
+    async def _async_handle_set_master_config(self, call: ServiceCall):
+        """Handle set master config service call."""
+        invalid_attrs = []
+
+        # Check for invalid attributes
+        if invalid_attrs := [
+            attr for attr in call.data if not hasattr(self.config, attr)
+        ]:
+            raise HomeAssistantError(f"Invalid attributes - {invalid_attrs}")
+
+        # Set values now we know all valid
+        for attr, value in call.data.items():
+            setattr(self.config, attr, value)
+
+        await self.save()
+        async_dispatcher_send(
+            self._hass,
+            f"{DOMAIN}_master_config_update",
+        )

--- a/custom_components/view_assist/services.yaml
+++ b/custom_components/view_assist/services.yaml
@@ -258,3 +258,7 @@ save_view:
       default: true
       selector:
         boolean:
+set_master_config:
+  name: "Set View Assist master config"
+  descritpion: "Set config parameters for all View Assist devices"
+

--- a/custom_components/view_assist/websocket.py
+++ b/custom_components/view_assist/websocket.py
@@ -24,6 +24,7 @@ from .helpers import (
     get_entity_id_by_browser_id,
     get_mimic_entity_id,
 )
+from .master_config import MASTER_CONFIG
 from .timers import TIMERS, VATimers
 
 _LOGGER = logging.getLogger(__name__)
@@ -146,9 +147,16 @@ async def async_register_websockets(hass: HomeAssistant):
 
             async_dispatcher_connect(
                 hass,
+                f"{DOMAIN}_master_config_update",
+                send_config_update,
+            )
+
+            async_dispatcher_connect(
+                hass,
                 f"{DOMAIN}_{config.entry_id}_navigate",
                 browser_navigate,
             )
+
         else:
             async_dispatcher_connect(
                 hass,
@@ -250,6 +258,7 @@ async def async_register_websockets(hass: HomeAssistant):
             )
             try:
                 output = {
+                    "master_config": hass.data[DOMAIN][MASTER_CONFIG].config,
                     "browser_id": browser_id,
                     "entity_id": entity_id,
                     "mimic_device": mimic,


### PR DESCRIPTION
This PR adds a master config store

This data is available within the backend integration in 
```hass[view_assist][master_config].config```

and in the frontend in 

```
viewassist.config.master_config
```
ie
```
var_show_date: |-
    [[[
      return viewassist.config.master_config.show_date
    ]]]
```
There is a service `set_master_config` which will allow the setting of any of the attributes in MasterConfig and will error if trying to set anythign not defined in MasterConfig.

The config will persist a HA restart (stored in view_assist.master_config in config/.storage)

ATM, we only have show_date defined as a config attribute but you can add whatever you need in the MasterConfig class in master_config.py.
