### PR TITLE
Add custom_conversation intent event handler

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,14 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,17 @@
+name: Validate
+
+on:
+  push: 
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  validate-hacs:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: HACS validation
+        uses: "hacs/action@main"
+        with:
+          category: "integration"

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -36,6 +36,7 @@ CYCLE_VIEWS = ["music", "info", "weather", "clock"]
 
 BROWSERMOD_DOMAIN = "browser_mod"
 REMOTE_ASSIST_DISPLAY_DOMAIN = "remote_assist_display"
+CUSTOM_CONVERSATION_DOMAIN = "custom_conversation"
 USE_VA_NAVIGATION_FOR_BROWSERMOD = True
 
 IMAGE_PATH = "images"
@@ -190,6 +191,7 @@ ATTR_MAX_REPEATS = "max_repeats"
 
 VA_ATTRIBUTE_UPDATE_EVENT = "va_attr_update_event_{}"
 VA_BACKGROUND_UPDATE_EVENT = "va_background_update_{}"
+CC_CONVERSATION_ENDED_EVENT = f"{CUSTOM_CONVERSATION_DOMAIN}_conversation_ended"
 
 
 class RuntimeData:

--- a/custom_components/view_assist/manifest.json
+++ b/custom_components/view_assist/manifest.json
@@ -2,10 +2,10 @@
   "domain": "view_assist",
   "name": "View Assist",
   "version": "0.0.1",
-  "documentation": "https://github.com/dinki/View-Assist",
-  "dependencies": ["lovelace"],
   "codeowners": ["@dinki"],
   "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/dinki/view_assist_integration",
+  "issue_tracker": "https://github.com/dinki/view_assist_integration/issues",
   "requirements": ["wordtodigits==1.0.2"]
-
 }


### PR DESCRIPTION
So, this listens for the custom_coversation_conversation_ended event, maps the event data into a entity state update event and passes this to _async_on_intent_device_change.

So, if CC is not being used, nothing will happen.  If it is being used, events will get processed.

I have tested with CC but via text conversation as do not have a setup to use voice atm in dev (had to fudge the fact no device id in text conversation).