### PR TITLE
Support local timezone for timers

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -45,15 +45,6 @@ async def async_migrate_entry(
     if entry.minor_version == 1 and entry.options:
         new_options = {**entry.options}
         # Migrate options keys
-        migration_keys = {
-            "blur pop up": "blur_pop_up",
-            "flashing bar": "flashing_bar",
-            "Home Assistant Voice Satellite": "home_assistant_voice_satellite",
-            "HassMic": "hassmic",
-            "Stream Assist": "stream_assist",
-            "BrowserMod": "browser_mod",
-            "Remote Assist Display": "remote_assist_display",
-        }
         for key, value in new_options.items():
             if isinstance(value, str) and value in OPTION_KEY_MIGRATIONS:
                 new_options[key] = OPTION_KEY_MIGRATIONS.get(value)

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -21,6 +21,7 @@ from .const import (
     VAConfigEntry,
 )
 from .helpers import get_device_id_from_entity_id
+from .timers import VATimers
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,9 +73,8 @@ class ViewAssistSensor(SensorEntity):
         )
 
         # Add listener to timer changes
-        self.hass.data[DOMAIN]["timers"].store.add_listener(
-            self.entity_id, self.va_update
-        )
+        timers: VATimers = self.hass.data[DOMAIN]["timers"]
+        timers.store.add_listener(self.entity_id, self.va_update)
 
     @callback
     def va_update(self, *args):
@@ -125,7 +125,8 @@ class ViewAssistSensor(SensorEntity):
         attrs.update(self.config.runtime_data.extra_data)
 
         # display timers
-        attrs["timers"] = self.hass.data[DOMAIN]["timers"].get_timers(
+        timers: VATimers = self.hass.data[DOMAIN]["timers"]
+        attrs["timers"] = timers.get_timers(
             device_or_entity_id=self.entity_id, include_expired=True
         )
 


### PR DESCRIPTION
This change corrects a previous update to timers to use UTC across the board.  It now stores timers as timezone niave timestamps, uses these for calculations of time remaining/intervals etc by comparing to timezone niave datetime.now and then formats the output to local timezone (as set in HA) for events and service responses.

It has been tested against Europe/London (currently GMT+1) and EST (currently GMT-5).