### PR TITLE
added: negate need for browsermod

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -126,6 +126,7 @@ async def run_if_first_display_instance(hass: HomeAssistant, entry: VAConfigEntr
     # Run dashboard and view setup
     async def setup_frontend(*args):
         # Load websockets
+        hass.data[DOMAIN]["va_browser_ids"] = {}
         await async_register_websockets(hass)
 
         http = HTTPManager(hass, entry)

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -48,7 +48,7 @@ JSMODULES = [
     {
         "name": "View Assist Helper",
         "filename": "view_assist.js",
-        "version": "1.0.6",
+        "version": "1.0.7",
     },
 ]
 

--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -268,6 +268,14 @@ class EntityListeners:
                 {"target": self.browser_or_device_id, "path": path},
             )
 
+        else:
+            # Use own VA navigation
+            async_dispatcher_send(
+                self.hass,
+                f"{DOMAIN}_{self.config_entry.entry_id}_event",
+                VAEvent("navigate", {"path": path}),
+            )
+
         # If this was a revert action, end here
         if is_revert_action:
             return

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -105,6 +105,8 @@ def get_config_entry_by_entity_id(hass: HomeAssistant, entity_id: str) -> VAConf
 
 def get_device_name_from_id(hass: HomeAssistant, device_id: str) -> str:
     """Get the browser_id for the device based on device domain."""
+    if device_id.startswith("va-"):
+        return device_id
     device_reg = dr.async_get(hass)
     device = device_reg.async_get(device_id)
 
@@ -117,6 +119,25 @@ def get_device_id_from_entity_id(hass: HomeAssistant, entity_id: str) -> str:
     if entity := entity_registry.async_get(entity_id):
         return entity.device_id
     return None
+
+
+def get_devices_for_domain(hass: HomeAssistant, domain: str) -> list[dr.DeviceEntry]:
+    """Get all devices for a domain."""
+    device_reg = dr.async_get(hass)
+    entries = list(
+        hass.config_entries.async_entries(
+            domain, include_ignore=False, include_disabled=False
+        )
+    )
+
+    if entries:
+        devices = []
+        for entry in entries:
+            devices.extend(
+                device_reg.devices.get_devices_for_config_entry_id(entry.entry_id)
+            )
+        return devices
+    return []
 
 
 def get_device_id_from_name(hass: HomeAssistant, device_name: str) -> str:
@@ -202,8 +223,13 @@ def get_entity_id_by_browser_id(hass: HomeAssistant, browser_id: str) -> str:
     """
     # Browser ID is same as device name, so get device id to VA device with display device
     # set to this id
-    if device_id := get_device_id_from_name(hass, browser_id):
-        # Get all instances of view assist for browser id
+    if browser_id.startswith("va-"):
+        device_id = browser_id
+    else:
+        device_id = get_device_id_from_name(hass, browser_id)
+
+    # Get all instances of view assist for browser id
+    if device_id:
         entry_ids = [
             entry.entry_id
             for entry in hass.config_entries.async_entries(DOMAIN)


### PR DESCRIPTION
Instructions to use.

- Ensure browsermod is removed or disabled.  And remove the browsermod javascript resource.
- Refresh your browser and it will then create its own browser_id
- Go into your VA device config and in the display device dropdown you will see devices begining va- (these are VA created browser ids - select this and hey presto, it should all work as if you had browsermod but without the annoying interaction icon.

To find out your browser id (until we have a page to display this), go into f12 dev tools and type 'viewassist' and hit enter on the console command line and you will see the browser id.