### PR TITLE
Fix intent device configuration removal

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -69,6 +69,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: VAConfigEntry):
     # make accessible throughout integration
     entry.runtime_data = RuntimeData()
     set_runtime_data_from_config(entry)
+    
+    # Handle intent_device specially - if not in config, don't set it
+    if "intent_device" not in entry.data:
+        entry.runtime_data.intent_device = ""
 
     # Add config change listener
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
@@ -94,7 +98,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: VAConfigEntry):
     )
 
     return True
-
 
 async def run_if_first_instance(hass: HomeAssistant, entry: VAConfigEntry):
     """Things to run only for first instance of integration."""


### PR DESCRIPTION
This PR addresses an issue where intent devices couldn't be properly removed once configured. The fix initializes intent_device to an empty string when not present in configuration, allowing users to clear the field from the UI without breaking existing functionality or requiring complete device recreation.