### PR TITLE
Remove timer attribute from sensors and HA-VPE mute switch listener name fix

### DIFF
--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -556,6 +556,7 @@ class EntityListeners:
 
     def get_mute_switch(self, target_device: str, mic_type: str):
         """Get mute switch."""
+        _LOGGER.debug("Mic type: %s, Target device: %s", mic_type, target_device)
 
         if mic_type == VAMicType.STREAM_ASSIST:
             return target_device.replace("sensor", "switch").replace("_stt", "_mic")
@@ -564,7 +565,9 @@ class EntityListeners:
                 "simple_state", "microphone"
             )
         if mic_type == VAMicType.HA_VOICE_SATELLITE:
-            return target_device.replace("assist_satellite", "switch") + "_mute"
+            return target_device.replace("assist_satellite", "switch", 1).replace(
+                "assist_satellite", "mute"
+            )
 
         return None
 

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -124,12 +124,6 @@ class ViewAssistSensor(SensorEntity):
         # Add extra_data attributes from runtime data
         attrs.update(self.config.runtime_data.extra_data)
 
-        # display timers
-        timers: VATimers = self.hass.data[DOMAIN]["timers"]
-        attrs["timers"] = timers.get_timers(
-            device_or_entity_id=self.entity_id, include_expired=True
-        )
-
         return attrs
 
     def set_entity_state(self, **kwargs):


### PR DESCRIPTION
Changes in this PR

1. Removed the timer attribute from sensors - issue #53
2. Corrected name of HA VPE mute entity