### PR TITLE
Improve mute switch determination

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.start import async_at_started
 
 from .alarm_repeater import ALARMS, VAAlarmRepeater
 from .const import (
+    CONF_MIC_TYPE,
     DOMAIN,
     OPTION_KEY_MIGRATIONS,
     RuntimeData,
@@ -50,6 +51,7 @@ async def async_migrate_entry(
         entry.minor_version,
         entry.options,
     )
+    new_options = {}
     if entry.minor_version == 1 and entry.options:
         new_options = {**entry.options}
         # Migrate options keys
@@ -57,8 +59,15 @@ async def async_migrate_entry(
             if isinstance(value, str) and value in OPTION_KEY_MIGRATIONS:
                 new_options[key] = OPTION_KEY_MIGRATIONS.get(value)
 
+    if entry.minor_version < 3 and entry.options:
+        # Remove mic_type key
+        if "mic_type" in entry.options:
+            new_options = {**entry.options}
+            new_options.pop(CONF_MIC_TYPE)
+
+    if new_options != entry.options:
         hass.config_entries.async_update_entry(
-            entry, options=new_options, minor_version=2, version=1
+            entry, options=new_options, minor_version=3, version=1
         )
 
         _LOGGER.debug(

--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -39,7 +39,6 @@ from .const import (
     CONF_INTENT_DEVICE,
     CONF_MEDIAPLAYER_DEVICE,
     CONF_MIC_DEVICE,
-    CONF_MIC_TYPE,
     CONF_MIC_UNMUTE,
     CONF_MUSIC,
     CONF_MUSICPLAYER_DEVICE,
@@ -60,7 +59,6 @@ from .const import (
     DEFAULT_FONT_STYLE,
     DEFAULT_HIDE_HEADER,
     DEFAULT_HIDE_SIDEBAR,
-    DEFAULT_MIC_TYPE,
     DEFAULT_MIC_UNMUTE,
     DEFAULT_MODE,
     DEFAULT_NAME,
@@ -84,7 +82,6 @@ from .const import (
     VAAssistPrompt,
     VAConfigEntry,
     VAIconSizes,
-    VAMicType,
     VAType,
 )
 from .helpers import (
@@ -195,7 +192,7 @@ class ViewAssistConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for View Assist."""
 
     VERSION = 1
-    MINOR_VERSION = 2
+    MINOR_VERSION = 3
 
     @staticmethod
     @callback
@@ -539,18 +536,6 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
                         CONF_WEATHER_ENTITY, DEFAULT_WEATHER_ENITITY
                     ),
                 ): EntitySelector(EntitySelectorConfig(domain=WEATHER_DOMAIN)),
-                vol.Optional(
-                    CONF_MIC_TYPE,
-                    default=self.config_entry.options.get(
-                        CONF_MIC_TYPE, DEFAULT_MIC_TYPE
-                    ),
-                ): SelectSelector(
-                    SelectSelectorConfig(
-                        translation_key="mic_type_selector",
-                        options=[e.value for e in VAMicType],
-                        mode=SelectSelectorMode.DROPDOWN,
-                    )
-                ),
                 vol.Optional(
                     CONF_MODE,
                     default=self.config_entry.options.get(CONF_MODE, DEFAULT_MODE),

--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -95,7 +95,23 @@ _LOGGER = logging.getLogger(__name__)
 BASE_SCHEMA = {
     vol.Required(CONF_NAME): str,
     vol.Required(CONF_MIC_DEVICE): EntitySelector(
-        EntitySelectorConfig(domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN])
+        EntitySelectorConfig(
+            filter=[
+                EntityFilterSelectorConfig(
+                    integration="esphome", domain=ASSIST_SAT_DOMAIN
+                ),
+                EntityFilterSelectorConfig(
+                    integration="hassmic", domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN]
+                ),
+                EntityFilterSelectorConfig(
+                    integration="stream_assist",
+                    domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN],
+                ),
+                EntityFilterSelectorConfig(
+                    integration="wyoming", domain=ASSIST_SAT_DOMAIN
+                ),
+            ]
+        )
     ),
     vol.Required(CONF_MEDIAPLAYER_DEVICE): EntitySelector(
         EntitySelectorConfig(domain=MEDIAPLAYER_DOMAIN)
@@ -334,7 +350,24 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
             vol.Required(
                 CONF_MIC_DEVICE, default=self.config_entry.data[CONF_MIC_DEVICE]
             ): EntitySelector(
-                EntitySelectorConfig(domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN])
+                EntitySelectorConfig(
+                    filter=[
+                        EntityFilterSelectorConfig(
+                            integration="esphome", domain=ASSIST_SAT_DOMAIN
+                        ),
+                        EntityFilterSelectorConfig(
+                            integration="hassmic",
+                            domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN],
+                        ),
+                        EntityFilterSelectorConfig(
+                            integration="stream_assist",
+                            domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN],
+                        ),
+                        EntityFilterSelectorConfig(
+                            integration="wyoming", domain=ASSIST_SAT_DOMAIN
+                        ),
+                    ]
+                )
             ),
             vol.Required(
                 CONF_MEDIAPLAYER_DEVICE,

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -99,14 +99,6 @@ class VAIconSizes(StrEnum):
     LARGE = "8vw"
 
 
-class VAMicType(StrEnum):
-    """Mic types."""
-
-    HA_VOICE_SATELLITE = "home_assistant_voice_satellite"
-    HASS_MIC = "hassmic"
-    STREAM_ASSIST = "stream_assist"
-
-
 class VADisplayType(StrEnum):
     """Display types."""
 
@@ -131,7 +123,6 @@ CONF_FONT_STYLE = "font_style"
 CONF_STATUS_ICONS = "status_icons"
 CONF_USE_24H_TIME = "use_24_hour_time"
 CONF_WEATHER_ENTITY = "weather_entity"
-CONF_MIC_TYPE = "mic_type"
 CONF_VIEW_TIMEOUT = "view_timeout"
 CONF_DO_NOT_DISTURB = "do_not_disturb"
 CONF_USE_ANNOUNCE = "use_announce"
@@ -144,6 +135,7 @@ CONF_ROTATE_BACKGROUND_SOURCE = "rotate_background_source"
 CONF_ROTATE_BACKGROUND_PATH = "rotate_background_path"
 CONF_ROTATE_BACKGROUND_LINKED_ENTITY = "rotate_background_linked_entity"
 CONF_ROTATE_BACKGROUND_INTERVAL = "rotate_background_interval"
+CONF_MIC_TYPE = "mic_type"
 
 # Config default values
 DEFAULT_NAME = "View Assist"
@@ -160,7 +152,6 @@ DEFAULT_FONT_STYLE = "Roboto"
 DEFAULT_STATUS_ICONS = []
 DEFAULT_USE_24H_TIME = False
 DEFAULT_WEATHER_ENITITY = "weather.home"
-DEFAULT_MIC_TYPE = VAMicType.HA_VOICE_SATELLITE
 DEFAULT_MODE = "normal"
 DEFAULT_VIEW_TIMEOUT = 20
 DEFAULT_DND = False
@@ -230,7 +221,6 @@ class RuntimeData:
 
         # Default options
         self.weather_entity: str = DEFAULT_WEATHER_ENITITY
-        self.mic_type: VAMicType = DEFAULT_MIC_TYPE
         self.mode: str = DEFAULT_MODE
         self.view_timeout: int = DEFAULT_VIEW_TIMEOUT
         self.hide_sidebar: bool = DEFAULT_HIDE_SIDEBAR

--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -70,9 +70,9 @@ class EntityListeners:
         self.rotate_background_task: Task | None = None
 
         # Add microphone mute switch listener
-        mic_device = config_entry.runtime_data.mic_device
-        mic_type = config_entry.runtime_data.mic_type
-        mute_switch = get_mute_switch_entity_id(mic_device, mic_type)
+        mute_switch = get_mute_switch_entity_id(
+            hass, config_entry.runtime_data.mic_device
+        )
 
         # Add browser navigate service listener
         config_entry.async_on_unload(

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -23,7 +23,6 @@ from .const import (
     VAMODE_REVERTS,
     VAConfigEntry,
     VADisplayType,
-    VAMicType,
     VAMode,
     VAType,
 )
@@ -245,17 +244,17 @@ def get_entity_id_by_browser_id(hass: HomeAssistant, browser_id: str) -> str:
     return None
 
 
-def get_mute_switch_entity_id(target_device: str, mic_type: str):
-    """Get mute switch."""
-    if mic_type == VAMicType.STREAM_ASSIST:
-        return target_device.replace("sensor", "switch").replace("_stt", "_mic")
-    if mic_type == VAMicType.HASS_MIC:
-        return target_device.replace("sensor", "switch").replace(
-            "simple_state", "microphone"
-        )
-    if mic_type == VAMicType.HA_VOICE_SATELLITE:
-        return target_device.replace("assist_satellite", "switch") + "_mute"
-
+def get_mute_switch_entity_id(hass: HomeAssistant, mic_entity_id: str) -> str | None:
+    """Get the mute switch entity id for a device id relating to the mic entity."""
+    entity_registry = er.async_get(hass)
+    if mic_entity := entity_registry.async_get(mic_entity_id):
+        device_id = mic_entity.device_id
+        device_entities = er.async_entries_for_device(entity_registry, device_id)
+        for entity in device_entities:
+            if entity.domain == "switch" and entity.entity_id.endswith(
+                ("_mute", "_mic", "_microphone")
+            ):
+                return entity.entity_id
     return None
 
 

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -95,16 +95,11 @@ class ViewAssistSensor(SensorEntity):
         """Return entity attributes."""
         r = self.config.runtime_data
 
-        # TODO: To be readded when entity selection logic fixed
-        # mic_device = self.config.runtime_data.mic_device
-        # mic_type = self.config.runtime_data.mic_type
-        # mute_switch = get_mute_switch_entity_id(mic_device, mic_type)
-
         attrs = {
             "type": r.type,
             "mic_device": r.mic_device,
             "mic_device_id": get_device_id_from_entity_id(self.hass, r.mic_device),
-            # "mute_switch": mute_switch, - to be added when entity selection logic fixed
+            "mute_switch": get_mute_switch_entity_id(self.hass, r.mic_device),
             "mediaplayer_device": r.mediaplayer_device,
             "musicplayer_device": r.musicplayer_device,
             "mode": r.mode,
@@ -118,7 +113,6 @@ class ViewAssistSensor(SensorEntity):
             "use_announce": r.use_announce,
             "background": r.background,
             "weather_entity": r.weather_entity,
-            "mic_type": self.get_option_key_migration_value(r.mic_type),
             "voice_device_id": self._voice_device_id,
         }
 


### PR DESCRIPTION
In this PR

1. Selecting the mute switch entity
    - Determines the mute switch from looking at the selected mic device and finding a corresponding entity within the same device that ends with mic, microphone, or mute
    - Sets this as an attribute on the VA sensor
2. Limiting the mic device list to supported integrations
    - HassMic, Stream Assist, Wyoming, Esphome (HA VPE) entities that are sensor or assist_satellite