### PR TITLE
fix: ability to clear intent device option

### DIFF
--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -379,7 +379,9 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
             ): EntitySelector(EntitySelectorConfig(domain=MEDIAPLAYER_DOMAIN)),
             vol.Optional(
                 CONF_INTENT_DEVICE,
-                default=self.config_entry.data.get(CONF_INTENT_DEVICE, vol.UNDEFINED),
+                description={
+                    "suggested_value": self.config_entry.data.get(CONF_INTENT_DEVICE)
+                },
             ): EntitySelector(EntitySelectorConfig(domain=SENSOR_DOMAIN)),
         }
 


### PR DESCRIPTION
Fixes that you cannot clear the intent device once set.  Now you can.