### PR TITLE
Enhance Status Icons with Dynamic Creation and Add Menu System

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,6 @@ This integration can be installed by downloading the [view_assist](https://githu
 
 Questions, problems, concerns?  Reach out to us on Discord or use the 'Issues' above
 
-# Blueprints for beta
-
-During the beta, the blueprints and other files will be held in the [View Assist Integration Prep](https://github.com/dinki/View-Assist/tree/viewassist-integrationprep) branch.  These integrations have been modified to work with the new View Assist integration and you will need to use these new versions.  These will eventually be stored in the main View Assist branch after the beta and the links in the wiki will once again work as written.  For now, though, you will want to install these using the buttons in the README.md file in each of the [blueprint directories](https://github.com/dinki/View-Assist/tree/viewassist-integrationprep/View_Assist_custom_sentences).
-
-Here's an example:
-
-
-![image](https://github.com/user-attachments/assets/5ec48a91-ec3f-49d9-8e67-eae717e49bd9)
-
-
 # Help
 
 Need help?  Hop on our Discord channel and we'll give you a boost!

--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -29,6 +29,7 @@ from .helpers import (
 )
 from .http_url import HTTPManager
 from .js_modules import JSModuleRegistration
+from .menu_manager import MenuManager
 from .services import VAServices
 from .templates import setup_va_templates
 from .timers import TIMERS, VATimers
@@ -158,6 +159,10 @@ async def load_common_functions(hass: HomeAssistant, entry: VAConfigEntry):
     timers = VATimers(hass, entry)
     hass.data[DOMAIN][TIMERS] = timers
     await timers.load()
+
+    # Setup Menu Manager
+    menu_manager = MenuManager(hass, entry)
+    hass.data[DOMAIN]["menu_manager"] = menu_manager
 
     # Load javascript modules
     jsloader = JSModuleRegistration(hass)

--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -31,6 +31,8 @@ from .const import (
     CONF_DEV_MIMIC,
     CONF_DISPLAY_DEVICE,
     CONF_DO_NOT_DISTURB,
+    CONF_ENABLE_MENU,
+    CONF_ENABLE_MENU_TIMEOUT,
     CONF_FONT_STYLE,
     CONF_HIDE_HEADER,
     CONF_HIDE_SIDEBAR,
@@ -38,6 +40,8 @@ from .const import (
     CONF_INTENT,
     CONF_INTENT_DEVICE,
     CONF_MEDIAPLAYER_DEVICE,
+    CONF_MENU_ITEMS,
+    CONF_MENU_TIMEOUT,
     CONF_MIC_DEVICE,
     CONF_MIC_UNMUTE,
     CONF_MUSIC,
@@ -56,9 +60,13 @@ from .const import (
     DEFAULT_ASSIST_PROMPT,
     DEFAULT_DASHBOARD,
     DEFAULT_DND,
+    DEFAULT_ENABLE_MENU,
+    DEFAULT_ENABLE_MENU_TIMEOUT,
     DEFAULT_FONT_STYLE,
     DEFAULT_HIDE_HEADER,
     DEFAULT_HIDE_SIDEBAR,
+    DEFAULT_MENU_ITEMS,
+    DEFAULT_MENU_TIMEOUT,
     DEFAULT_MIC_UNMUTE,
     DEFAULT_MODE,
     DEFAULT_NAME,
@@ -66,6 +74,8 @@ from .const import (
     DEFAULT_ROTATE_BACKGROUND_INTERVAL,
     DEFAULT_ROTATE_BACKGROUND_PATH,
     DEFAULT_ROTATE_BACKGROUND_SOURCE,
+    DEFAULT_SHOW_MENU_BUTTON,
+    CONF_SHOW_MENU_BUTTON,
     DEFAULT_STATUS_ICON_SIZE,
     DEFAULT_STATUS_ICONS,
     DEFAULT_TYPE,
@@ -546,6 +556,44 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
                     CONF_HIDE_HEADER,
                     default=self.config_entry.options.get(
                         CONF_HIDE_HEADER, DEFAULT_HIDE_HEADER
+                    ),
+                ): bool,
+                vol.Optional(
+                    CONF_ENABLE_MENU,
+                    default=self.config_entry.options.get(
+                        CONF_ENABLE_MENU, DEFAULT_ENABLE_MENU
+                    ),
+                ): bool,
+                vol.Optional(
+                    CONF_MENU_ITEMS,
+                    default=self.config_entry.options.get(
+                        CONF_MENU_ITEMS, DEFAULT_MENU_ITEMS
+                    ),
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        translation_key="menu_items_selector",
+                        options=[],
+                        mode=SelectSelectorMode.LIST,
+                        multiple=True,
+                        custom_value=True,
+                    )
+                ),
+                vol.Optional(
+                    CONF_ENABLE_MENU_TIMEOUT,
+                    default=self.config_entry.options.get(
+                        CONF_ENABLE_MENU_TIMEOUT, DEFAULT_ENABLE_MENU_TIMEOUT
+                    ),
+                ): bool,
+                vol.Optional(
+                    CONF_MENU_TIMEOUT,
+                    default=self.config_entry.options.get(
+                        CONF_MENU_TIMEOUT, DEFAULT_MENU_TIMEOUT
+                    ),
+                ): int,
+                vol.Optional(
+                    CONF_SHOW_MENU_BUTTON,
+                    default=self.config_entry.options.get(
+                        CONF_SHOW_MENU_BUTTON, DEFAULT_SHOW_MENU_BUTTON
                     ),
                 ): bool,
             }

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -137,6 +137,13 @@ CONF_ROTATE_BACKGROUND_LINKED_ENTITY = "rotate_background_linked_entity"
 CONF_ROTATE_BACKGROUND_INTERVAL = "rotate_background_interval"
 CONF_MIC_TYPE = "mic_type"
 
+# Menu configuration
+CONF_ENABLE_MENU = "enable_menu"
+CONF_MENU_ITEMS = "menu_items"
+CONF_ENABLE_MENU_TIMEOUT = "enable_menu_timeout"
+CONF_MENU_TIMEOUT = "menu_timeout"
+CONF_SHOW_MENU_BUTTON = "show_menu_button"
+
 # Config default values
 DEFAULT_NAME = "View Assist"
 DEFAULT_TYPE = VAType.VIEW_AUDIO
@@ -163,6 +170,15 @@ DEFAULT_ROTATE_BACKGROUND = False
 DEFAULT_ROTATE_BACKGROUND_SOURCE = "local_sequence"
 DEFAULT_ROTATE_BACKGROUND_PATH = f"{IMAGE_PATH}/backgrounds"
 DEFAULT_ROTATE_BACKGROUND_INTERVAL = 60
+
+# Menu defaults
+DEFAULT_ENABLE_MENU = False
+DEFAULT_MENU_ITEMS = ["home", "weather"]
+DEFAULT_ENABLE_MENU_TIMEOUT = False
+DEFAULT_MENU_TIMEOUT = 10
+DEFAULT_SHOW_MENU_BUTTON = False
+DEFAULT_MENU_ICON_SIZE = "6vw"
+DEFAULT_MENU_ICON_COLOR = "white"
 
 # Service attributes
 ATTR_EVENT_NAME = "event_name"

--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -44,6 +44,7 @@ from .helpers import (
     async_get_filesystem_images,
     get_device_name_from_id,
     get_display_type_from_browser_id,
+    ensure_menu_button_at_end,
     get_entity_attribute,
     get_entity_id_from_conversation_device_id,
     get_key,
@@ -219,6 +220,21 @@ class EntityListeners:
         # If new navigate before revert timer has expired, cancel revert timer.
         if not is_revert_action:
             self._cancel_display_revert_task()
+
+        # Store current path in entity attributes to help menu filtering
+        entity_id = get_sensor_entity_from_instance(
+            self.hass, self.config_entry.entry_id
+        )
+        
+        # Update current path attribute
+        await self.hass.services.async_call(
+            DOMAIN,
+            "set_state",
+            {
+                "entity_id": entity_id,
+                "current_path": path,
+            },
+        )
 
         # Do navigation and set revert if needed
         browser_id = get_device_name_from_id(
@@ -414,6 +430,8 @@ class EntityListeners:
         elif mic_mute_new_state == "off" and "mic" in status_icons:
             status_icons.remove("mic")
 
+        ensure_menu_button_at_end(status_icons)
+
         self.config_entry.runtime_data.status_icons = status_icons
         self.update_entity()
 
@@ -444,6 +462,8 @@ class EntityListeners:
             status_icons.append("mediaplayer")
         elif not mp_mute_new_state and "mediaplayer" in status_icons:
             status_icons.remove("mediaplayer")
+
+        ensure_menu_button_at_end(status_icons)
 
         self.config_entry.runtime_data.status_icons = status_icons
         self.update_entity()
@@ -594,6 +614,8 @@ class EntityListeners:
         elif not dnd_new_state and "dnd" in status_icons:
             status_icons.remove("dnd")
 
+        ensure_menu_button_at_end(status_icons)
+
         self.config_entry.runtime_data.status_icons = status_icons
         self.update_entity()
 
@@ -615,6 +637,8 @@ class EntityListeners:
         # Now add back any you want
         if new_mode in modes and new_mode not in status_icons:
             status_icons.append(new_mode)
+
+        ensure_menu_button_at_end(status_icons)
 
         self.config_entry.runtime_data.status_icons = status_icons
         self.update_entity()

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -5,7 +5,6 @@ import json
 import logging
 from pathlib import Path
 from typing import Any, List, Optional, Union
-import json
 
 import requests
 

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -1,9 +1,11 @@
 """Helper functions."""
 
 from functools import reduce
+import json
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, List, Optional, Union
+import json
 
 import requests
 
@@ -71,6 +73,105 @@ def ensure_list(value: str | list[str]):
         value = (value.replace("[", "").replace("]", "").replace('"', "")).split(",")
         return value if value else []
     return []
+
+def ensure_menu_button_at_end(status_icons: list[str]) -> None:
+    """Ensure menu button is always the rightmost (last) status icon."""
+    if "menu" in status_icons:
+        status_icons.remove("menu")
+        status_icons.append("menu")
+
+def normalize_status_items(raw_input: Any) -> Optional[Union[str, List[str]]]:
+    """Normalize and validate status item input.
+
+    Handles various input formats:
+    - Single string
+    - List of strings
+    - JSON string representing a list
+    - Dictionary with attributes
+
+    Returns:
+    - Single string
+    - List of strings
+    - None if invalid input
+    """
+    import json
+
+    if raw_input is None:
+        return None
+
+    if isinstance(raw_input, str):
+        if raw_input.startswith("[") and raw_input.endswith("]"):
+            try:
+                parsed = json.loads(raw_input)
+                if isinstance(parsed, list):
+                    string_items = [str(item) for item in parsed if item]
+                    return string_items if string_items else None
+                return None
+            except json.JSONDecodeError:
+                return raw_input if raw_input else None
+        return raw_input if raw_input else None
+
+    if isinstance(raw_input, list):
+        string_items = [str(item) for item in raw_input if item]
+        return string_items if string_items else None
+
+    if isinstance(raw_input, dict):
+        if "id" in raw_input:
+            return str(raw_input["id"])
+        if "name" in raw_input:
+            return str(raw_input["name"])
+        if "value" in raw_input:
+            return str(raw_input["value"])
+
+    return None
+
+
+def arrange_status_icons(menu_items: list[str], system_icons: list[str],
+                         show_menu_button: bool = False) -> list[str]:
+    """Arrange status icons in the correct order."""
+    result = [item for item in menu_items if item != "menu"]
+
+    for icon in system_icons:
+        if icon != "menu" and icon not in result:
+            result.append(icon)
+
+    if show_menu_button:
+        ensure_menu_button_at_end(result)
+
+    return result
+
+
+def update_status_icons(current_icons: list[str],
+                        add_icons: list[str] = None,
+                        remove_icons: list[str] = None,
+                        menu_items: list[str] = None,
+                        show_menu_button: bool = False) -> list[str]:
+    """Update a status icons list by adding and/or removing icons."""
+    result = current_icons.copy()
+
+    if remove_icons:
+        for icon in remove_icons:
+            if icon == "menu" and show_menu_button:
+                continue
+            if icon in result:
+                result.remove(icon)
+
+    if add_icons:
+        for icon in add_icons:
+            if icon not in result:
+                if icon != "menu":
+                    result.append(icon)
+
+    if menu_items is not None:
+        system_icons = [
+            icon for icon in result if icon not in menu_items and icon != "menu"]
+        menu_icon_list = [icon for icon in result if icon in menu_items]
+        result = arrange_status_icons(
+            menu_icon_list, system_icons, show_menu_button)
+    elif show_menu_button:
+        ensure_menu_button_at_end(result)
+
+    return result
 
 
 def get_entity_attribute(hass: HomeAssistant, entity_id: str, attribute: str) -> Any:

--- a/custom_components/view_assist/manifest.json
+++ b/custom_components/view_assist/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/dinki/view_assist_integration/issues",
   "requirements": ["wordtodigits==1.0.2"],
-  "version": "2025.4.0"
+  "version": "2025.4.1"
 }

--- a/custom_components/view_assist/menu_manager.py
+++ b/custom_components/view_assist/menu_manager.py
@@ -1,0 +1,463 @@
+"""Menu manager for View Assist."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+import logging
+from typing import Dict, List, Optional, Tuple, Union
+
+from homeassistant.core import Event, HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .const import (
+    CONF_ENABLE_MENU,
+    CONF_ENABLE_MENU_TIMEOUT,
+    CONF_MENU_ITEMS,
+    CONF_MENU_TIMEOUT,
+    CONF_SHOW_MENU_BUTTON,
+    DEFAULT_ENABLE_MENU,
+    DEFAULT_ENABLE_MENU_TIMEOUT,
+    DEFAULT_MENU_ITEMS,
+    DEFAULT_MENU_TIMEOUT,
+    DEFAULT_SHOW_MENU_BUTTON,
+    DOMAIN,
+    VAConfigEntry,
+    VAEvent,
+)
+from .helpers import (
+    arrange_status_icons,
+    ensure_menu_button_at_end,
+    get_config_entry_by_entity_id,
+    get_sensor_entity_from_instance,
+    normalize_status_items,
+    update_status_icons,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+StatusItemType = Union[str, List[str]]
+
+
+@dataclass
+class MenuState:
+    """Structured representation of a menu's state."""
+
+    entity_id: str
+    active: bool = False
+    configured_items: List[str] = field(default_factory=list)
+    status_icons: List[str] = field(default_factory=list)
+    system_icons: List[str] = field(default_factory=list)
+    menu_timeout: Optional[asyncio.Task] = None
+    item_timeouts: Dict[Tuple[str, str, bool], asyncio.Task] = field(
+        default_factory=dict
+    )
+
+
+class MenuManager:
+    """Class to manage View Assist menus."""
+
+    def __init__(self, hass: HomeAssistant, config: VAConfigEntry) -> None:
+        """Initialize menu manager."""
+        self.hass = hass
+        self.config = config
+        self._menu_states: Dict[str, MenuState] = {}
+        self._pending_updates: Dict[str, Dict[str, any]] = {}
+        self._update_event = asyncio.Event()
+        self._update_task: Optional[asyncio.Task] = None
+
+        config.async_on_unload(self.cleanup)
+
+        self.hass.bus.async_listen_once(
+            "homeassistant_started", self._on_ha_started)
+
+    async def _on_ha_started(self, event: Event) -> None:
+        """Initialize menu states and start processor after Home Assistant has started."""
+        for entry_id in [
+            entry.entry_id for entry in self.hass.config_entries.async_entries(DOMAIN)
+        ]:
+            entity_id = get_sensor_entity_from_instance(self.hass, entry_id)
+            if entity_id:
+                self._get_or_create_state(entity_id)
+
+        self._update_task = self.config.async_create_background_task(
+            self.hass,
+            self._update_processor(),
+            name="VA Menu Manager",
+        )
+
+    def _get_or_create_state(self, entity_id: str) -> MenuState:
+        """Get or create a MenuState for the entity."""
+        if entity_id not in self._menu_states:
+            self._menu_states[entity_id] = MenuState(entity_id=entity_id)
+
+            state = self.hass.states.get(entity_id)
+            if state:
+                menu_items = state.attributes.get(
+                    CONF_MENU_ITEMS, DEFAULT_MENU_ITEMS)
+                self._menu_states[entity_id].configured_items = (
+                    menu_items if menu_items else []
+                )
+
+                status_icons = state.attributes.get("status_icons", [])
+                self._menu_states[entity_id].status_icons = (
+                    status_icons if status_icons else []
+                )
+
+                self._menu_states[entity_id].active = state.attributes.get(
+                    "menu_active", False
+                )
+
+                self._menu_states[entity_id].system_icons = [
+                    icon
+                    for icon in self._menu_states[entity_id].status_icons
+                    if icon not in self._menu_states[entity_id].configured_items
+                    and icon != "menu"
+                ]
+
+        return self._menu_states[entity_id]
+
+    async def toggle_menu(
+        self, entity_id: str, show: Optional[bool] = None, timeout: Optional[int] = None
+    ) -> None:
+        """Toggle menu visibility for an entity."""
+        config_entry = get_config_entry_by_entity_id(self.hass, entity_id)
+        if not config_entry or not config_entry.options.get(
+            CONF_ENABLE_MENU, DEFAULT_ENABLE_MENU
+        ):
+            _LOGGER.debug(
+                "Menu not enabled or config not found for %s", entity_id)
+            return
+
+        state = self.hass.states.get(entity_id)
+        if not state:
+            _LOGGER.warning("Entity %s not found", entity_id)
+            return
+
+        menu_state = self._get_or_create_state(entity_id)
+        current_active = menu_state.active
+
+        if show is None:
+            show = not current_active
+
+        self._cancel_timeout(entity_id)
+
+        show_menu_button = config_entry.options.get(
+            CONF_SHOW_MENU_BUTTON, DEFAULT_SHOW_MENU_BUTTON
+        )
+
+        changes = {}
+
+        # Always refresh system_icons from current status_icons in the entity state
+        current_status_icons = state.attributes.get("status_icons", [])
+
+        # Update system_icons whenever we toggle the menu
+        system_icons = [
+            icon
+            for icon in current_status_icons
+            if icon not in menu_state.configured_items and icon != "menu"
+        ]
+        # Update the stored system_icons to match current reality
+        menu_state.system_icons = system_icons
+
+        if show:
+            updated_icons = arrange_status_icons(
+                menu_state.configured_items,
+                system_icons,
+                show_menu_button
+            )
+            menu_state.active = True
+            menu_state.status_icons = updated_icons
+            changes = {"status_icons": updated_icons, "menu_active": True}
+
+            if timeout is not None:
+                self._setup_timeout(entity_id, timeout)
+            elif config_entry.options.get(
+                CONF_ENABLE_MENU_TIMEOUT, DEFAULT_ENABLE_MENU_TIMEOUT
+            ):
+                timeout_value = config_entry.options.get(
+                    CONF_MENU_TIMEOUT, DEFAULT_MENU_TIMEOUT
+                )
+                self._setup_timeout(entity_id, timeout_value)
+        else:
+            # When hiding menu, use the system icons with menu button if needed
+            updated_icons = system_icons.copy()
+            if show_menu_button:
+                ensure_menu_button_at_end(updated_icons)
+
+            menu_state.active = False
+            menu_state.status_icons = updated_icons
+            changes = {"status_icons": updated_icons, "menu_active": False}
+
+        if changes:
+            await self._update_entity_state(entity_id, changes)
+
+            async_dispatcher_send(
+                self.hass,
+                f"{DOMAIN}_{config_entry.entry_id}_event",
+                VAEvent("menu_update", {"menu_active": show}),
+            )
+
+    async def add_menu_item(
+        self,
+        entity_id: str,
+        status_item: StatusItemType,
+        menu: bool = False,
+        timeout: Optional[int] = None,
+    ) -> None:
+        """Add status item(s) to the entity's status icons or menu items."""
+        items = normalize_status_items(status_item)
+        if isinstance(items, str):
+            items = [items]
+        elif items is None:
+            items = []
+
+        if not items:
+            _LOGGER.warning("No valid items to add")
+            return
+
+        config_entry = get_config_entry_by_entity_id(self.hass, entity_id)
+        if not config_entry:
+            _LOGGER.warning("No config entry found for entity %s", entity_id)
+            return
+
+        menu_state = self._get_or_create_state(entity_id)
+        show_menu_button = config_entry.options.get(
+            CONF_SHOW_MENU_BUTTON, DEFAULT_SHOW_MENU_BUTTON
+        )
+        changes = {}
+
+        if menu:
+            # Update configured menu items
+            updated_items = menu_state.configured_items.copy()
+            changed = False
+
+            for item in items:
+                if item not in updated_items:
+                    updated_items.append(item)
+                    changed = True
+
+            if changed:
+                menu_state.configured_items = updated_items
+                changes["menu_items"] = updated_items
+
+                # If menu is active, update visible status icons too
+                if menu_state.active:
+                    updated_icons = arrange_status_icons(
+                        menu_state.configured_items,
+                        menu_state.system_icons,
+                        show_menu_button
+                    )
+                    menu_state.status_icons = updated_icons
+                    changes["status_icons"] = updated_icons
+        else:
+            # Update status icons directly
+            updated_icons = update_status_icons(
+                menu_state.status_icons,
+                add_icons=items,
+                menu_items=menu_state.configured_items if menu_state.active else None,
+                show_menu_button=show_menu_button
+            )
+
+            if updated_icons != menu_state.status_icons:
+                menu_state.status_icons = updated_icons
+                changes["status_icons"] = updated_icons
+
+        if changes:
+            await self._update_entity_state(entity_id, changes)
+
+        if timeout is not None:
+            for item in items:
+                await self._setup_item_timeout(entity_id, item, timeout, menu)
+
+    async def remove_menu_item(
+        self, entity_id: str, status_item: StatusItemType, from_menu: bool = False
+    ) -> None:
+        """Remove status item(s) from the entity's status icons or menu items."""
+        items = normalize_status_items(status_item)
+        if isinstance(items, str):
+            items = [items]
+        elif items is None:
+            items = []
+
+        if not items:
+            _LOGGER.warning("No valid items to remove")
+            return
+
+        config_entry = get_config_entry_by_entity_id(self.hass, entity_id)
+        if not config_entry:
+            return
+
+        menu_state = self._get_or_create_state(entity_id)
+        show_menu_button = config_entry.options.get(
+            CONF_SHOW_MENU_BUTTON, DEFAULT_SHOW_MENU_BUTTON
+        )
+        changes = {}
+
+        if from_menu:
+            # Remove from configured menu items
+            updated_items = [
+                item for item in menu_state.configured_items if item not in items
+            ]
+
+            if updated_items != menu_state.configured_items:
+                menu_state.configured_items = updated_items
+                changes["menu_items"] = updated_items
+
+                # If menu is active, update visible status icons too
+                if menu_state.active:
+                    updated_icons = arrange_status_icons(
+                        menu_state.configured_items,
+                        menu_state.system_icons,
+                        show_menu_button
+                    )
+                    menu_state.status_icons = updated_icons
+                    changes["status_icons"] = updated_icons
+        else:
+            # Remove from status icons directly
+            updated_icons = update_status_icons(
+                menu_state.status_icons,
+                remove_icons=items,
+                menu_items=menu_state.configured_items if menu_state.active else None,
+                show_menu_button=show_menu_button
+            )
+
+            if updated_icons != menu_state.status_icons:
+                menu_state.status_icons = updated_icons
+                changes["status_icons"] = updated_icons
+
+        if changes:
+            await self._update_entity_state(entity_id, changes)
+
+        for item in items:
+            self._cancel_item_timeout(entity_id, item, from_menu)
+
+    def _setup_timeout(self, entity_id: str, timeout: int) -> None:
+        """Setup timeout for menu."""
+        menu_state = self._get_or_create_state(entity_id)
+
+        if menu_state.menu_timeout and not menu_state.menu_timeout.done():
+            menu_state.menu_timeout.cancel()
+            menu_state.menu_timeout = None
+
+        async def _timeout_task():
+            try:
+                await asyncio.sleep(timeout)
+                await self.toggle_menu(entity_id, False)
+            except asyncio.CancelledError:
+                pass
+
+        menu_state.menu_timeout = self.config.async_create_background_task(
+            self.hass,
+            _timeout_task(),
+            name=f"VA Menu Timeout {entity_id}",
+        )
+
+    def _cancel_timeout(self, entity_id: str) -> None:
+        """Cancel any existing timeout for an entity."""
+        if entity_id not in self._menu_states:
+            return
+
+        menu_state = self._menu_states[entity_id]
+
+        if menu_state.menu_timeout and not menu_state.menu_timeout.done():
+            menu_state.menu_timeout.cancel()
+            menu_state.menu_timeout = None
+
+    async def _setup_item_timeout(
+        self, entity_id: str, menu_item: str, timeout: int, is_menu_item: bool = False
+    ) -> None:
+        """Set up a timeout for a specific menu item."""
+        menu_state = self._get_or_create_state(entity_id)
+
+        item_key = (entity_id, menu_item, is_menu_item)
+
+        self._cancel_item_timeout(entity_id, menu_item, is_menu_item)
+
+        async def _item_timeout_task():
+            try:
+                await asyncio.sleep(timeout)
+                await self.remove_menu_item(entity_id, menu_item, is_menu_item)
+            except asyncio.CancelledError:
+                pass
+
+        menu_state.item_timeouts[item_key] = self.config.async_create_background_task(
+            self.hass,
+            _item_timeout_task(),
+            name=f"VA Item Timeout {entity_id} {menu_item}",
+        )
+
+    def _cancel_item_timeout(
+        self, entity_id: str, menu_item: str, is_menu_item: bool = False
+    ) -> None:
+        """Cancel timeout for a specific menu item."""
+        if entity_id not in self._menu_states:
+            return
+
+        menu_state = self._menu_states[entity_id]
+
+        item_key = (entity_id, menu_item, is_menu_item)
+
+        if (
+            item_key in menu_state.item_timeouts
+            and not menu_state.item_timeouts[item_key].done()
+        ):
+            menu_state.item_timeouts[item_key].cancel()
+            menu_state.item_timeouts.pop(item_key)
+
+    async def _update_entity_state(
+        self, entity_id: str, changes: Dict[str, any]
+    ) -> None:
+        """Update entity state with changes, batching updates when possible."""
+        if not changes:
+            return
+
+        if entity_id not in self._pending_updates:
+            self._pending_updates[entity_id] = {}
+
+        self._pending_updates[entity_id].update(changes)
+
+        self._update_event.set()
+
+    async def _update_processor(self) -> None:
+        """Process updates in an event-driven way."""
+        while True:
+            try:
+                await self._update_event.wait()
+                self._update_event.clear()
+
+                updates = self._pending_updates.copy()
+                self._pending_updates.clear()
+
+                for entity_id, changes in updates.items():
+                    if not changes:
+                        continue
+
+                    changes["entity_id"] = entity_id
+
+                    try:
+                        await self.hass.services.async_call(
+                            DOMAIN, "set_state", changes
+                        )
+                    except Exception as e:
+                        _LOGGER.error(
+                            "Error updating entity %s: %s", entity_id, str(e))
+            except asyncio.CancelledError:
+                break
+            except Exception as err:
+                _LOGGER.error(
+                    "Unexpected error in update processor: %s", str(err))
+                await asyncio.sleep(1)
+
+    async def cleanup(self) -> None:
+        """Clean up resources when the integration is unloaded."""
+        for menu_state in self._menu_states.values():
+            if menu_state.menu_timeout and not menu_state.menu_timeout.done():
+                menu_state.menu_timeout.cancel()
+
+            for timeout in menu_state.item_timeouts.values():
+                if not timeout.done():
+                    timeout.cancel()
+
+        if self._update_task and not self._update_task.done():
+            self._update_task.cancel()

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -14,6 +14,12 @@ from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import (
+    CONF_ENABLE_MENU,
+    CONF_MENU_ITEMS,
+    CONF_SHOW_MENU_BUTTON,
+    DEFAULT_ENABLE_MENU,
+    DEFAULT_MENU_ITEMS,
+    DEFAULT_SHOW_MENU_BUTTON,
     DOMAIN,
     OPTION_KEY_MIGRATIONS,
     VA_ATTRIBUTE_UPDATE_EVENT,
@@ -114,6 +120,10 @@ class ViewAssistSensor(SensorEntity):
             "background": r.background,
             "weather_entity": r.weather_entity,
             "voice_device_id": self._voice_device_id,
+            "enable_menu": self.config.options.get(CONF_ENABLE_MENU, DEFAULT_ENABLE_MENU),
+            "menu_items": self.config.options.get(CONF_MENU_ITEMS, DEFAULT_MENU_ITEMS),
+            "show_menu_button": self.config.options.get(CONF_SHOW_MENU_BUTTON, DEFAULT_SHOW_MENU_BUTTON),
+            "menu_active": self._get_menu_active_state(),
         }
 
         # Only add these attributes if they exist
@@ -164,6 +174,17 @@ class ViewAssistSensor(SensorEntity):
                 self.config.runtime_data.extra_data[k] = v
 
         self.schedule_update_ha_state(True)
+
+    def _get_menu_active_state(self) -> bool:
+        """Get the menu active state from menu manager."""
+        menu_manager = self.hass.data[DOMAIN].get("menu_manager")
+        if not menu_manager:
+            return False
+            
+        if hasattr(menu_manager, "_menu_states") and self.entity_id in menu_manager._menu_states:
+            return menu_manager._menu_states[self.entity_id].active
+            
+        return False
 
     @property
     def icon(self):

--- a/custom_components/view_assist/services.py
+++ b/custom_components/view_assist/services.py
@@ -1,7 +1,9 @@
 """Integration services."""
 
 from asyncio import TimerHandle
+import json
 import logging
+from typing import Any, Union, List, Optional, Callable, cast
 
 import voluptuous as vol
 
@@ -50,6 +52,8 @@ from .helpers import get_mimic_entity_id
 from .timers import TIMERS, VATimers, decode_time_sentence
 
 _LOGGER = logging.getLogger(__name__)
+
+StatusItemType = Union[str, List[str]]
 
 
 NAVIGATE_SERVICE_SCHEMA = vol.Schema(
@@ -136,6 +140,28 @@ LOAD_DASHVIEW_SERVICE_SCHEMA = DASHVIEW_SERVICE_SCHEMA.extend(
         vol.Required(ATTR_REDOWNLOAD_FROM_REPO, default=False): bool,
         vol.Optional(ATTR_COMMUNITY_VIEW, default=False): bool,
         vol.Required(ATTR_BACKUP_CURRENT_VIEW, default=False): bool,
+    }
+)
+TOGGLE_MENU_SERVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+        vol.Optional("show", default=True): cv.boolean,
+        vol.Optional("timeout"): vol.Any(int, None),
+    }
+)
+ADD_STATUS_ITEM_SERVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_id, 
+        vol.Required("status_item"): vol.Any(str, [str]),
+        vol.Optional("menu", default=False): cv.boolean,
+        vol.Optional("timeout"): vol.Any(int, None),
+    }
+)
+REMOVE_STATUS_ITEM_SERVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+        vol.Required("status_item"): vol.Any(str, [str]),
+        vol.Optional("menu", default=False): cv.boolean,
     }
 )
 
@@ -225,6 +251,27 @@ class VAServices:
             "save_view",
             self.async_handle_save_view,
             schema=DASHVIEW_SERVICE_SCHEMA,
+        )
+
+        self.hass.services.async_register(
+            DOMAIN,
+            "toggle_menu",
+            self.async_handle_toggle_menu,
+            schema=TOGGLE_MENU_SERVICE_SCHEMA,
+        )
+
+        self.hass.services.async_register(
+            DOMAIN,
+            "add_status_item",
+            self.async_handle_add_status_item,
+            schema=ADD_STATUS_ITEM_SERVICE_SCHEMA,
+        )
+
+        self.hass.services.async_register(
+            DOMAIN,
+            "remove_status_item",
+            self.async_handle_remove_status_item,
+            schema=REMOVE_STATUS_ITEM_SERVICE_SCHEMA,
         )
 
     # -----------------------------------------------------------------------
@@ -423,3 +470,61 @@ class VAServices:
             await dm.save_view(view_name)
         except (DownloadManagerException, DashboardManagerException) as ex:
             raise HomeAssistantError(ex) from ex
+
+    # ----------------------------------------------------------------
+    # MENU
+    # ----------------------------------------------------------------
+    async def async_handle_toggle_menu(self, call: ServiceCall):
+        """Handle toggle menu service call."""
+        entity_id = call.data.get(ATTR_ENTITY_ID)
+        if not entity_id:
+            _LOGGER.error("No entity_id provided in toggle_menu service call")
+            return
+
+        show = call.data.get("show", True)
+        timeout = call.data.get("timeout")
+        
+        menu_manager = self.hass.data[DOMAIN]["menu_manager"]
+        await menu_manager.toggle_menu(entity_id, show, timeout=timeout)
+
+    async def async_handle_add_status_item(self, call: ServiceCall):
+        """Handle add status item service call."""
+        entity_id = call.data.get(ATTR_ENTITY_ID)
+        if not entity_id:
+            _LOGGER.error("No entity_id provided in add_status_item service call")
+            return
+
+        raw_status_item = call.data.get("status_item")
+        menu = call.data.get("menu", False)
+        timeout = call.data.get("timeout")
+        
+        status_items = self._process_status_item_input(raw_status_item)
+        if not status_items:
+            _LOGGER.error("Invalid or empty status_item provided")
+            return
+
+        menu_manager = self.hass.data[DOMAIN]["menu_manager"]
+        await menu_manager.add_menu_item(entity_id, status_items, menu, timeout)
+
+    async def async_handle_remove_status_item(self, call: ServiceCall):
+        """Handle remove status item service call."""
+        entity_id = call.data.get(ATTR_ENTITY_ID)
+        if not entity_id:
+            _LOGGER.error("No entity_id provided in remove_status_item service call")
+            return
+
+        raw_status_item = call.data.get("status_item")
+        menu = call.data.get("menu", False)
+
+        status_items = self._process_status_item_input(raw_status_item)
+        if not status_items:
+            _LOGGER.error("Invalid or empty status_item provided")
+            return
+
+        menu_manager = self.hass.data[DOMAIN]["menu_manager"]
+        await menu_manager.remove_menu_item(entity_id, status_items, menu)
+
+    def _process_status_item_input(self, raw_input: Any) -> Optional[StatusItemType]:
+        """Process and validate status item input."""
+        from .helpers import normalize_status_items
+        return normalize_status_items(raw_input)

--- a/custom_components/view_assist/services.yaml
+++ b/custom_components/view_assist/services.yaml
@@ -249,3 +249,96 @@ save_view:
       required: true
       selector:
         text:
+set_master_config:
+  name: "Set View Assist master config"
+  description: "Set config parameters for all View Assist devices"
+toggle_menu:
+  name: Toggle menu
+  description: Show or hide the menu for a View Assist entity
+  fields:
+    entity_id:
+      name: "Entity ID"
+      description: "The entity ID of the View Assist device"
+      required: true
+      selector:
+        entity:
+          integration: view_assist
+          domain:
+            - sensor
+    show:
+      name: "Show"
+      description: "Whether to show (true) or hide (false) the menu"
+      required: false
+      default: true
+      selector:
+        boolean:
+    timeout:
+      name: "Timeout"
+      description: "Optional timeout in seconds to automatically close the menu (overrides configured timeout)"
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 300
+          step: 1
+add_status_item:
+  name: Add status item
+  description: Add one or more items to the menu/status bar of a View Assist entity
+  fields:
+    entity_id:
+      name: "Entity ID"
+      description: "The entity ID of the View Assist device"
+      required: true
+      selector:
+        entity:
+          integration: view_assist
+          domain:
+            - sensor
+    status_item:
+      name: "Status Item(s)"
+      description: "The status item(s) to add. Can be a single item or a list of items. Each item can be a system item name like 'weather' or a custom action format like 'view:weather|cloud'"
+      required: true
+      selector:
+        object:
+    menu:
+      name: "Add to Menu Items"
+      description: "If true, adds the item(s) to the configured menu items list that appears when the menu is toggled. If false, adds to status icons (always visible)."
+      required: false
+      default: false
+      selector:
+        boolean:
+    timeout:
+      name: "Timeout"
+      description: "Optional timeout in seconds after which the item(s) will be automatically removed"
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 3600
+          step: 1
+remove_status_item:
+  name: Remove status item
+  description: Remove one or more items from the menu/status bar of a View Assist entity
+  fields:
+    entity_id:
+      name: "Entity ID"
+      description: "The entity ID of the View Assist device"
+      required: true
+      selector:
+        entity:
+          integration: view_assist
+          domain:
+            - sensor
+    status_item:
+      name: "Status Item(s)"
+      description: "The status item(s) to remove. Can be a single item or a list of items."
+      required: true
+      selector:
+        object:
+    from_menu_items:
+      name: "Remove from Menu Items"
+      description: "If true, removes the item(s) from the configured menu items list. If false, removes from status icons."
+      required: false
+      default: false
+      selector:
+        boolean:

--- a/custom_components/view_assist/translations/en.json
+++ b/custom_components/view_assist/translations/en.json
@@ -91,7 +91,7 @@
           "rotate_background_linked_entity": "Linked entity",
           "rotate_background_interval": "Rotation interval",
           "assist_prompt": "Assist prompt",
-          "status_icons_size": "Icon size",
+          "status_icons_size": "Status Icon size",
           "font_style": "Font style",
           "status_icons": "Launch icons",
           "use_24_hour_time": "Use 24h time",

--- a/custom_components/view_assist/translations/en.json
+++ b/custom_components/view_assist/translations/en.json
@@ -91,12 +91,17 @@
           "rotate_background_linked_entity": "Linked entity",
           "rotate_background_interval": "Rotation interval",
           "assist_prompt": "Assist prompt",
-          "status_icons_size": "Status icon size",
+          "status_icons_size": "Icon size",
           "font_style": "Font style",
           "status_icons": "Launch icons",
           "use_24_hour_time": "Use 24h time",
           "hide_sidebar": "Hide sidemenu",
-          "hide_header": "Hide header bar"
+          "hide_header": "Hide header bar",
+          "enable_menu": "Enable menu",
+          "menu_items": "Menu items",
+          "enable_menu_timeout": "Enable menu timeout",
+          "menu_timeout": "Menu timeout (seconds)",
+          "show_menu_button": "Show menu button in status bar"
         },
         "data_description": {
           "dashboard": "The base dashboard for View Assist (do not include trailing slash)",
@@ -108,12 +113,17 @@
           "rotate_background_linked_entity": "View Assist entity to link the background to",
           "rotate_background_interval": "Interval in minutes to rotate the background",
           "assist_prompt": "The Assist notification prompt style to use for wake word detection and intent processing",
-          "status_icons_size": "Size of the icons in the status icon display",
+          "status_icons_size": "Size of the icons in status and menu displays",
           "font_style": "The default font to use for this satellite device. Font name must match perfectly and be available",
           "status_icons": "Advanced option! List of custom launch icons to set on start up. Do not change this if you do not know what you are doing",
           "use_24_hour_time": "Sets clock display to 24 hour time when enabled",
           "hide_sidebar": "Hide the sidemenu on the display via View Assist",
-          "hide_header": "Hide the header on the display via View Assist"
+          "hide_header": "Hide the header on the display via View Assist",
+          "enable_menu": "Enable the menu system for this device",
+          "menu_items": "List of menu items to display when menu is activated. Format: type:target|icon|label",
+          "enable_menu_timeout": "Enable automatic timeout for menu",
+          "menu_timeout": "Time in seconds before menu automatically closes",
+          "show_menu_button": "Show a permanent menu button in the status bar"
         }
       },
       "default_options": {
@@ -151,12 +161,12 @@
         "flashing_bar": "Flashing bar at bottom"
       }
     },
-      "status_icons_size_selector": {
-        "options": {
-          "6vw": "Small",
-          "7vw": "Medium",
-          "8vw": "Large"
-        }
+    "status_icons_size_selector": {
+      "options": {
+        "6vw": "Small",
+        "7vw": "Medium",
+        "8vw": "Large"
+      }
     },
     "mic_type_selector": {
       "options": {
@@ -179,6 +189,9 @@
         "download": "Download random image from Unsplash",
         "link_to_entity": "Linked to another View Assist device"
       }
+    },
+    "menu_items_selector": {
+      "description": "Menu items in format: type:target|icon|label - Examples: view:weather|weather-sunny|Weather, entity:light.kitchen|lightbulb|Kitchen"
     }
   }
 }


### PR DESCRIPTION
## Overview
This PR enhances the status icon capabilities with dynamic management and adds a comprehensive menu system. With these changes, status icons can now be created dynamically (without needing to edit dashboard YAML), and an optional menu system allows users to toggle display of additional status icons for navigation and actions.

## Key Features

### Status Icons Enhancement
- **Dynamic Creation**: Status icons can now be programmatically added/removed via service calls
- **Flexible Format**: New `type:target|icon|label` format for defining icon behavior
- **Action Types**: Support for view navigation, entity control, and service calls
- **Timeouts**: Optional automatic removal after specified time period
- **Proper Layout**: Menu button (when enabled) always appears at end of status bar

### New Menu System
- **Optional Feature**: Completely opt-in from
- **Toggle Function**: Show/hide menu items with service call or menu button
- **Dynamic Items**: Menu items use same format as status icons
- **Context Awareness**: Auto-filters current view from menu options
- **Auto-Timeout**: Configurable auto-close timeout

### Implementation
- **Menu Manager**: New component that handles menu state, toggles, and timeouts
- **Template System**: Three new dynamic templates for generating icons:
  - `dynamic_view_item`: For navigation actions
  - `dynamic_entity_item`: For entity toggle controls
  - `dynamic_service_item`: For service calls
- **Helper Functions**: New normalization and processing functions

## New Services

### `toggle_menu`
Show or hide the menu for a View Assist entity.
```yaml
service: view_assist.toggle_menu
data:
  entity_id: sensor.view_assist_living_room
  show: true  # optional, defaults to true
  timeout: 15  # optional, overrides configured timeout temporarily
```

### `add_status_item`
Add one or more items to the status bar or menu.
```yaml
service: view_assist.add_status_item
data:
  entity_id: sensor.view_assist_living_room
  status_item: "view:weather|weather-sunny"  # or list of items
  menu: false  # false = status bar, true = menu items
  timeout: 30  # optional, auto-remove after timeout
```

### `remove_status_item`
Remove one or more items from the status bar or menu.
```yaml
service: view_assist.remove_status_item
data:
  entity_id: sensor.view_assist_living_room
  status_item: "view:weather|weather-sunny"  # or list of items
  from_menu_items: false  # false = status bar, true = menu items
```

## Configuration Options
- **enable_menu**: Turn on/off menu functionality
- **menu_items**: List of items to show when menu is active
- **enable_menu_timeout**: Auto-close menu after timeout
- **menu_timeout**: Time in seconds before menu auto-closes
- **show_menu_button**: Show permanent menu button in status bar

## Status Icons vs Menu Icons

### Similarities
- Both use the same dynamic icon templates
- Both follow the same format: `type:target|icon|label`
- Both support the same action types (view, entity, service)
- Both can be programmatically managed through services
- Both can have timeouts for automatic removal of individual items

### Differences
- **Visibility**: Status icons are always visible; menu icons only appear when menu toggled
- **Behavior**: Menu automatically filters current view items; status bar shows all configured items
- **Interaction**: Menu items replace status icons when active, then revert when deactivated

## Dynamic Status Icon Format
The format `type:target|icon|label` is used for both status and menu items:

- **Type**: The action type - "view", "entity", or "service"
- **Target**: Path, entity_id, or service to act on
- **Icon**: Icon name without mdi: prefix (optional, defaults based on type)
- **Label**: Optional

Examples:
```
view:weather|weather-sunny|Weather
entity:light.kitchen|lightbulb|Kitchen
service:script.goodnight|moon|Goodnight
```

## Breaking Changes
None - all functionality is backward compatible with existing configurations.

## Notes
- Legacy status icons (added in dashboard YAML) continue to work
- Configuration referencing templates by name (e.g., "weather") still works
- Requires changes to the dashboard.yaml found [here](https://github.com/dinki/View-Assist/pull/161)