### PR TITLE
Master config defaults

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -352,7 +352,11 @@ def set_runtime_data_for_config(  # noqa: C901
     else:
         r = config_entry.runtime_data = DeviceRuntimeData()
         r.core = DeviceCoreConfig(**config_entry.data)
-        master_config_options = get_master_config_entry(hass).options
+        master_config_options = (
+            get_master_config_entry(hass).options
+            if get_master_config_entry(hass)
+            else {}
+        )
         # Dashboard options - handles sections
         for attr in r.dashboard.__dict__:
             if value := get_config_value(attr):

--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -1,6 +1,8 @@
 """View Assist custom integration."""
 
+from functools import reduce
 import logging
+from typing import Any
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_TYPE, Platform
@@ -11,19 +13,36 @@ from homeassistant.helpers.start import async_at_started
 
 from .alarm_repeater import ALARMS, VAAlarmRepeater
 from .const import (
+    CONF_ASSIST_PROMPT,
+    CONF_BACKGROUND,
+    CONF_BACKGROUND_MODE,
+    CONF_BACKGROUND_SETTINGS,
+    CONF_DEV_MIMIC,
+    CONF_DISPLAY_SETTINGS,
+    CONF_FONT_STYLE,
+    CONF_HIDE_HEADER,
+    CONF_HIDE_SIDEBAR,
     CONF_MIC_TYPE,
+    CONF_ROTATE_BACKGROUND,
+    CONF_ROTATE_BACKGROUND_INTERVAL,
+    CONF_ROTATE_BACKGROUND_LINKED_ENTITY,
+    CONF_ROTATE_BACKGROUND_PATH,
+    CONF_ROTATE_BACKGROUND_SOURCE,
+    CONF_SCREEN_MODE,
+    CONF_STATUS_ICON_SIZE,
+    CONF_STATUS_ICONS,
+    CONF_TIME_FORMAT,
+    CONF_USE_24H_TIME,
+    DEFAULT_VALUES,
     DOMAIN,
     OPTION_KEY_MIGRATIONS,
-    RuntimeData,
-    VAConfigEntry,
-    VAEvent,
-    VAType,
 )
 from .dashboard import DASHBOARD_MANAGER, DashboardManager
 from .entity_listeners import EntityListeners
 from .helpers import (
     ensure_list,
     get_device_name_from_id,
+    get_integration_entries,
     get_master_config_entry,
     is_first_instance,
 )
@@ -32,11 +51,31 @@ from .js_modules import JSModuleRegistration
 from .services import VAServices
 from .templates import setup_va_templates
 from .timers import TIMERS, VATimers
+from .typed import (
+    DeviceCoreConfig,
+    DeviceRuntimeData,
+    MasterConfigRuntimeData,
+    VABackgroundMode,
+    VAConfigEntry,
+    VAEvent,
+    VAScreenMode,
+    VATimeFormat,
+    VAType,
+)
 from .websocket import async_register_websockets
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+def migrate_to_section(entry: VAConfigEntry, params: list[str]):
+    """Build a section for the config entry."""
+    section = {}
+    for param in params:
+        if entry.options.get(param):
+            section[param] = entry.options.pop(param)
+    return section
 
 
 async def async_migrate_entry(
@@ -51,9 +90,8 @@ async def async_migrate_entry(
         entry.minor_version,
         entry.options,
     )
-    new_options = {}
-    if entry.minor_version == 1 and entry.options:
-        new_options = {**entry.options}
+    new_options = {**entry.options}
+    if entry.minor_version < 2 and entry.options:
         # Migrate options keys
         for key, value in new_options.items():
             if isinstance(value, str) and value in OPTION_KEY_MIGRATIONS:
@@ -62,12 +100,77 @@ async def async_migrate_entry(
     if entry.minor_version < 3 and entry.options:
         # Remove mic_type key
         if "mic_type" in entry.options:
-            new_options = {**entry.options}
             new_options.pop(CONF_MIC_TYPE)
+
+    if entry.minor_version < 4:
+        # Migrate to master config model
+
+        # Remove mimic device key as moved into master config
+        new_options.pop(CONF_DEV_MIMIC, None)
+
+        # Dashboard options
+        # Background has both moved into a section and also changed parameters
+        # Add section and migrate values
+        if CONF_BACKGROUND_SETTINGS not in new_options:
+            new_options[CONF_BACKGROUND_SETTINGS] = {}
+
+        for param in (
+            CONF_ROTATE_BACKGROUND,
+            CONF_BACKGROUND,
+            CONF_ROTATE_BACKGROUND_PATH,
+            CONF_ROTATE_BACKGROUND_INTERVAL,
+            CONF_ROTATE_BACKGROUND_LINKED_ENTITY,
+        ):
+            if param in new_options:
+                if param == CONF_ROTATE_BACKGROUND:
+                    new_options[CONF_BACKGROUND_SETTINGS][CONF_BACKGROUND_MODE] = (
+                        VABackgroundMode.DEFAULT_BACKGROUND
+                        if new_options[param] is False
+                        else new_options[CONF_ROTATE_BACKGROUND_SOURCE]
+                    )
+                    new_options.pop(param, None)
+                    new_options.pop(CONF_ROTATE_BACKGROUND_SOURCE, None)
+                else:
+                    new_options[CONF_BACKGROUND_SETTINGS][param] = new_options.pop(
+                        param, None
+                    )
+
+        # Display options
+        # Display options has both moved into a section and also changed parameters
+        if CONF_DISPLAY_SETTINGS not in new_options:
+            new_options[CONF_DISPLAY_SETTINGS] = {}
+
+        for param in [
+            CONF_ASSIST_PROMPT,
+            CONF_STATUS_ICON_SIZE,
+            CONF_FONT_STYLE,
+            CONF_STATUS_ICONS,
+            CONF_USE_24H_TIME,
+            CONF_HIDE_HEADER,
+        ]:
+            if param in new_options:
+                if param == CONF_USE_24H_TIME:
+                    new_options[CONF_DISPLAY_SETTINGS][CONF_TIME_FORMAT] = (
+                        VATimeFormat.HOUR_24
+                        if entry.options[param]
+                        else VATimeFormat.HOUR_12
+                    )
+                    new_options.pop(param)
+                elif param == CONF_HIDE_HEADER:
+                    mode = 0
+                    if new_options.pop(CONF_HIDE_HEADER, None):
+                        mode += 1
+                    if new_options.pop(CONF_HIDE_SIDEBAR, None):
+                        mode += 2
+                    new_options[CONF_DISPLAY_SETTINGS][CONF_SCREEN_MODE] = list(
+                        VAScreenMode
+                    )[mode].value
+                else:
+                    new_options[CONF_DISPLAY_SETTINGS][param] = new_options.pop(param)
 
     if new_options != entry.options:
         hass.config_entries.async_update_entry(
-            entry, options=new_options, minor_version=3, version=1
+            entry, options=new_options, minor_version=4, version=1
         )
 
         _LOGGER.debug(
@@ -87,9 +190,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: VAConfigEntry):
 
     # Add runtime data to config entry to have place to store data and
     # make accessible throughout integration
-    if not is_master_entry:
-        entry.runtime_data = RuntimeData()
-        set_runtime_data_from_config(entry)
+    set_runtime_data_for_config(hass, entry, is_master_entry)
+    _LOGGER.debug("Runtime Data: %s", entry.runtime_data.__dict__)
 
     # Add config change listener
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
@@ -118,11 +220,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: VAConfigEntry):
         await load_common_display_functions(hass, entry)
 
     else:
-        # Add runtime data to config entry to have place to store data and
-        # make accessible throughout integration
-        entry.runtime_data = RuntimeData()
-        set_runtime_data_from_config(entry)
-
         # Add config change listener
         entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
@@ -141,7 +238,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: VAConfigEntry):
         # Fire display device registration to setup display if first time config
         async_dispatcher_send(
             hass,
-            f"{DOMAIN}_{get_device_name_from_id(hass, entry.runtime_data.display_device)}_registered",
+            f"{DOMAIN}_{get_device_name_from_id(hass, entry.runtime_data.core.display_device)}_registered",
         )
 
     return True
@@ -190,23 +287,105 @@ async def load_common_display_functions(hass: HomeAssistant, entry: VAConfigEntr
     async_at_started(hass, setup_frontend)
 
 
-def set_runtime_data_from_config(config_entry: VAConfigEntry):
+def set_runtime_data_for_config(  # noqa: C901
+    hass: HomeAssistant, config_entry: VAConfigEntry, is_master: bool = False
+):
     """Set config.runtime_data attributes from matching config values."""
 
-    config_sources = [config_entry.data, config_entry.options]
-    for source in config_sources:
-        for k, v in source.items():
-            if hasattr(config_entry.runtime_data, k):
-                # This is a fix for config lists being a string
-                if isinstance(getattr(config_entry.runtime_data, k), list):
-                    setattr(config_entry.runtime_data, k, ensure_list(v))
-                else:
-                    setattr(config_entry.runtime_data, k, v)
+    def get_dn(dn_attr: str, data: dict[str, Any]):
+        """Get dotted notation attribute from config entry options dict."""
+        try:
+            if "." in dn_attr:
+                dn_list = dn_attr.split(".")
+            else:
+                dn_list = [dn_attr]
+            return reduce(dict.get, dn_list, data)
+        except (TypeError, KeyError):
+            return None
+
+    def get_config_value(
+        attr: str, is_master: bool = False
+    ) -> str | float | list | None:
+        value = get_dn(attr, dict(config_entry.options))
+        if not value and not is_master:
+            value = get_dn(attr, dict(master_config_options))
+        if not value:
+            value = get_dn(attr, DEFAULT_VALUES)
+
+        # This is a fix for config lists being a string
+        if isinstance(attr, list):
+            value = ensure_list(value)
+        return value
+
+    if is_master:
+        r = config_entry.runtime_data = MasterConfigRuntimeData()
+        # Dashboard options - handles sections
+        for attr in r.dashboard.__dict__:
+            if value := get_config_value(attr, is_master=True):
+                try:
+                    if attr in (CONF_BACKGROUND_SETTINGS, CONF_DISPLAY_SETTINGS):
+                        values = {}
+                        for sub_attr in getattr(r.dashboard, attr).__dict__:
+                            if sub_value := get_config_value(
+                                f"{attr}.{sub_attr}", is_master=True
+                            ):
+                                values[sub_attr] = sub_value
+                        value = type(getattr(r.dashboard, attr))(**values)
+                    setattr(r.dashboard, attr, value)
+                except Exception as ex:  # noqa: BLE001
+                    _LOGGER.error(
+                        "Error setting runtime data for %s - %s: %s",
+                        attr,
+                        type(getattr(r.dashboard, attr)),
+                        str(ex),
+                    )
+
+        # Default options - doesn't yet handle sections
+        for attr in r.default.__dict__:
+            if value := get_config_value(attr, is_master=True):
+                setattr(r.default, attr, value)
+
+        # Developer options
+        for attr in r.developer_settings.__dict__:
+            if value := get_config_value(attr, is_master=True):
+                setattr(r.developer_settings, attr, value)
+    else:
+        r = config_entry.runtime_data = DeviceRuntimeData()
+        r.core = DeviceCoreConfig(**config_entry.data)
+        master_config_options = get_master_config_entry(hass).options
+        # Dashboard options - handles sections
+        for attr in r.dashboard.__dict__:
+            if value := get_config_value(attr):
+                try:
+                    if isinstance(value, dict):
+                        values = {}
+                        for sub_attr in getattr(r.dashboard, attr).__dict__:
+                            if sub_value := get_config_value(f"{attr}.{sub_attr}"):
+                                values[sub_attr] = sub_value
+                        value = type(getattr(r.dashboard, attr))(**values)
+                    setattr(r.dashboard, attr, value)
+                except Exception as ex:  # noqa: BLE001
+                    _LOGGER.error(
+                        "Error setting runtime data for %s - %s: %s",
+                        attr,
+                        type(getattr(r.dashboard, attr)),
+                        str(ex),
+                    )
+
+        # Default options - doesn't yet handle sections
+        for attr in r.default.__dict__:
+            if value := get_config_value(attr):
+                setattr(r.default, attr, value)
 
 
 async def _async_update_listener(hass: HomeAssistant, config_entry: VAConfigEntry):
     """Handle config options update."""
     # Reload the integration when the options change.
+    is_master = config_entry.data[CONF_TYPE] == VAType.MASTER_CONFIG
+    if is_master:
+        if entries := get_integration_entries(hass):
+            for entry in entries:
+                await hass.config_entries.async_reload(entry.entry_id)
     await hass.config_entries.async_reload(config_entry.entry_id)
 
 

--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -12,12 +12,14 @@ from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
 from homeassistant.config_entries import ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_MODE, CONF_NAME, CONF_TYPE
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import SectionConfig, section
 from homeassistant.helpers.selector import (
-    DeviceSelector,
-    DeviceSelectorConfig,
     EntityFilterSelectorConfig,
     EntitySelector,
     EntitySelectorConfig,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
@@ -27,13 +29,15 @@ from .const import (
     BROWSERMOD_DOMAIN,
     CONF_ASSIST_PROMPT,
     CONF_BACKGROUND,
+    CONF_BACKGROUND_MODE,
+    CONF_BACKGROUND_SETTINGS,
     CONF_DASHBOARD,
-    CONF_DEV_MIMIC,
+    CONF_DEVELOPER_DEVICE,
+    CONF_DEVELOPER_MIMIC_DEVICE,
     CONF_DISPLAY_DEVICE,
+    CONF_DISPLAY_SETTINGS,
     CONF_DO_NOT_DISTURB,
     CONF_FONT_STYLE,
-    CONF_HIDE_HEADER,
-    CONF_HIDE_SIDEBAR,
     CONF_HOME,
     CONF_INTENT,
     CONF_INTENT_DEVICE,
@@ -42,104 +46,65 @@ from .const import (
     CONF_MIC_UNMUTE,
     CONF_MUSIC,
     CONF_MUSICPLAYER_DEVICE,
-    CONF_ROTATE_BACKGROUND,
     CONF_ROTATE_BACKGROUND_INTERVAL,
     CONF_ROTATE_BACKGROUND_LINKED_ENTITY,
     CONF_ROTATE_BACKGROUND_PATH,
-    CONF_ROTATE_BACKGROUND_SOURCE,
+    CONF_SCREEN_MODE,
     CONF_STATUS_ICON_SIZE,
     CONF_STATUS_ICONS,
-    CONF_USE_24H_TIME,
+    CONF_TIME_FORMAT,
     CONF_USE_ANNOUNCE,
     CONF_VIEW_TIMEOUT,
     CONF_WEATHER_ENTITY,
-    DEFAULT_ASSIST_PROMPT,
-    DEFAULT_DASHBOARD,
-    DEFAULT_DND,
-    DEFAULT_FONT_STYLE,
-    DEFAULT_HIDE_HEADER,
-    DEFAULT_HIDE_SIDEBAR,
-    DEFAULT_MIC_UNMUTE,
-    DEFAULT_MODE,
     DEFAULT_NAME,
-    DEFAULT_ROTATE_BACKGROUND,
-    DEFAULT_ROTATE_BACKGROUND_INTERVAL,
-    DEFAULT_ROTATE_BACKGROUND_PATH,
-    DEFAULT_ROTATE_BACKGROUND_SOURCE,
-    DEFAULT_STATUS_ICON_SIZE,
-    DEFAULT_STATUS_ICONS,
     DEFAULT_TYPE,
-    DEFAULT_USE_24H_TIME,
-    DEFAULT_USE_ANNOUNCE,
-    DEFAULT_VIEW_BACKGROUND,
-    DEFAULT_VIEW_HOME,
-    DEFAULT_VIEW_INTENT,
-    DEFAULT_VIEW_MUSIC,
-    DEFAULT_VIEW_TIMEOUT,
-    DEFAULT_WEATHER_ENITITY,
+    DEFAULT_VALUES,
     DOMAIN,
     REMOTE_ASSIST_DISPLAY_DOMAIN,
     VAAssistPrompt,
-    VAConfigEntry,
     VAIconSizes,
-    VAType,
 )
-from .helpers import (
-    get_devices_for_domain,
-    get_master_config_entry,
-    get_sensor_entity_from_instance,
-)
+from .helpers import get_devices_for_domain, get_master_config_entry
+from .typed import VABackgroundMode, VAConfigEntry, VAScreenMode, VATimeFormat, VAType
 
 _LOGGER = logging.getLogger(__name__)
 
-BASE_SCHEMA = {
-    vol.Required(CONF_NAME): str,
-    vol.Required(CONF_MIC_DEVICE): EntitySelector(
-        EntitySelectorConfig(
-            filter=[
-                EntityFilterSelectorConfig(
-                    integration="esphome", domain=ASSIST_SAT_DOMAIN
-                ),
-                EntityFilterSelectorConfig(
-                    integration="hassmic", domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN]
-                ),
-                EntityFilterSelectorConfig(
-                    integration="stream_assist",
-                    domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN],
-                ),
-                EntityFilterSelectorConfig(
-                    integration="wyoming", domain=ASSIST_SAT_DOMAIN
-                ),
-            ]
-        )
-    ),
-    vol.Required(CONF_MEDIAPLAYER_DEVICE): EntitySelector(
-        EntitySelectorConfig(domain=MEDIAPLAYER_DOMAIN)
-    ),
-    vol.Required(CONF_MUSICPLAYER_DEVICE): EntitySelector(
-        EntitySelectorConfig(domain=MEDIAPLAYER_DOMAIN)
-    ),
-    vol.Optional(CONF_INTENT_DEVICE, default=vol.UNDEFINED): EntitySelector(
-        EntitySelectorConfig(domain=SENSOR_DOMAIN)
-    ),
-}
-
-DISPLAY_SCHEMA = {
-    vol.Required(CONF_DISPLAY_DEVICE): DeviceSelector(
-        DeviceSelectorConfig(
-            filter=[
-                EntityFilterSelectorConfig(integration=BROWSERMOD_DOMAIN),
-                EntityFilterSelectorConfig(
-                    integration=REMOTE_ASSIST_DISPLAY_DOMAIN,
-                ),
-            ],
-        )
-    ),
-    vol.Required(CONF_DEV_MIMIC, default=False): bool,
-}
+BASE_DEVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): str,
+        vol.Required(CONF_MIC_DEVICE): EntitySelector(
+            EntitySelectorConfig(
+                filter=[
+                    EntityFilterSelectorConfig(
+                        integration="esphome", domain=ASSIST_SAT_DOMAIN
+                    ),
+                    EntityFilterSelectorConfig(
+                        integration="hassmic", domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN]
+                    ),
+                    EntityFilterSelectorConfig(
+                        integration="stream_assist",
+                        domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN],
+                    ),
+                    EntityFilterSelectorConfig(
+                        integration="wyoming", domain=ASSIST_SAT_DOMAIN
+                    ),
+                ]
+            )
+        ),
+        vol.Required(CONF_MEDIAPLAYER_DEVICE): EntitySelector(
+            EntitySelectorConfig(domain=MEDIAPLAYER_DOMAIN)
+        ),
+        vol.Required(CONF_MUSICPLAYER_DEVICE): EntitySelector(
+            EntitySelectorConfig(domain=MEDIAPLAYER_DOMAIN)
+        ),
+        vol.Optional(CONF_INTENT_DEVICE, default=vol.UNDEFINED): EntitySelector(
+            EntitySelectorConfig(domain=SENSOR_DOMAIN)
+        ),
+    }
+)
 
 
-def get_display_schema(
+def get_display_devices(
     hass: HomeAssistant, config: VAConfigEntry | None = None
 ) -> dict[str, Any]:
     """Get display device options."""
@@ -157,17 +122,14 @@ def get_display_schema(
 
     # Add current setting if not already in list
     if config is not None:
-        if config.runtime_data.display_device not in display_devices:
-            display_devices[config.runtime_data.display_device] = (
-                config.runtime_data.display_device
-            )
-
-    # Set a dummy device for initial setup
-    if not display_devices:
-        display_devices = {"dummy": "dummy"}
+        attrs = [CONF_DISPLAY_DEVICE, CONF_DEVELOPER_DEVICE]
+        for attr in attrs:
+            if d := config.data.get(attr):
+                if d not in display_devices:
+                    display_devices[d] = d
 
     # Make into options dict
-    options = [
+    return [
         {
             "value": key,
             "label": value,
@@ -175,40 +137,175 @@ def get_display_schema(
         for key, value in display_devices.items()
     ]
 
-    return (
-        {
-            vol.Required(CONF_DISPLAY_DEVICE): SelectSelector(
-                SelectSelectorConfig(
-                    options=options,
-                    mode=SelectSelectorMode.DROPDOWN,
+
+def get_dashboard_options_schema(config_entry: VAConfigEntry | None) -> vol.Schema:
+    """Return schema for dashboard options."""
+    is_master = (
+        config_entry is not None
+        and config_entry.data[CONF_TYPE] == VAType.MASTER_CONFIG
+    )
+
+    # Modify any option lists
+    if is_master:
+        background_source_options = [
+            e.value for e in VABackgroundMode if e != VABackgroundMode.LINKED
+        ]
+        background_extra = {}
+    else:
+        background_source_options = [e.value for e in VABackgroundMode]
+        background_extra = {
+            vol.Optional(CONF_ROTATE_BACKGROUND_LINKED_ENTITY): (
+                EntitySelector(
+                    EntitySelectorConfig(
+                        integration=DOMAIN,
+                        domain=SENSOR_DOMAIN,
+                        exclude_entities=[],
+                    )
                 )
-            ),
-            vol.Required(CONF_DEV_MIMIC, default=False): bool,
+            )
         }
-        if config is None
-        else {
-            vol.Required(
-                CONF_DISPLAY_DEVICE,
-                default=config.data.get(CONF_DISPLAY_DEVICE, vol.UNDEFINED),
-            ): SelectSelector(
+
+    BASE = {
+        vol.Optional(CONF_DASHBOARD): str,
+        vol.Optional(CONF_HOME): str,
+        vol.Optional(CONF_MUSIC): str,
+        vol.Optional(CONF_INTENT): str,
+    }
+    BACKGROUND_SETTINGS = {
+        vol.Optional(CONF_BACKGROUND_MODE): SelectSelector(
+            SelectSelectorConfig(
+                translation_key="rotate_backgound_source_selector",
+                options=background_source_options,
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+        vol.Optional(CONF_BACKGROUND): str,
+        vol.Optional(CONF_ROTATE_BACKGROUND_PATH): str,
+        vol.Optional(CONF_ROTATE_BACKGROUND_INTERVAL): int,
+    }
+
+    DISPLAY_SETTINGS = {
+        vol.Optional(CONF_ASSIST_PROMPT): SelectSelector(
+            SelectSelectorConfig(
+                translation_key="assist_prompt_selector",
+                options=[e.value for e in VAAssistPrompt],
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+        vol.Optional(CONF_STATUS_ICON_SIZE): SelectSelector(
+            SelectSelectorConfig(
+                translation_key="status_icons_size_selector",
+                options=[e.value for e in VAIconSizes],
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+        vol.Optional(CONF_FONT_STYLE): str,
+        vol.Optional(CONF_STATUS_ICONS): SelectSelector(
+            SelectSelectorConfig(
+                translation_key="status_icons_selector",
+                options=[],
+                mode=SelectSelectorMode.LIST,
+                multiple=True,
+                custom_value=True,
+            )
+        ),
+        vol.Optional(CONF_TIME_FORMAT): SelectSelector(
+            SelectSelectorConfig(
+                options=[e.value for e in VATimeFormat],
+                mode=SelectSelectorMode.DROPDOWN,
+                translation_key="lookup_selector",
+            )
+        ),
+        vol.Optional(CONF_SCREEN_MODE): SelectSelector(
+            SelectSelectorConfig(
+                options=[e.value for e in VAScreenMode],
+                mode=SelectSelectorMode.DROPDOWN,
+                translation_key="lookup_selector",
+            )
+        ),
+    }
+
+    BACKGROUND_SETTINGS.update(background_extra)
+
+    schema = BASE
+    schema[vol.Required(CONF_BACKGROUND_SETTINGS)] = section(
+        vol.Schema(BACKGROUND_SETTINGS), options=SectionConfig(collapsed=True)
+    )
+    schema[vol.Required(CONF_DISPLAY_SETTINGS)] = section(
+        vol.Schema(DISPLAY_SETTINGS), options=SectionConfig(collapsed=True)
+    )
+    return vol.Schema(schema)
+
+
+DEFAULT_OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_WEATHER_ENTITY): EntitySelector(
+            EntitySelectorConfig(domain=WEATHER_DOMAIN)
+        ),
+        vol.Optional(CONF_MODE): str,
+        vol.Optional(CONF_VIEW_TIMEOUT): NumberSelector(
+            NumberSelectorConfig(min=5, max=999, mode=NumberSelectorMode.BOX)
+        ),
+        vol.Optional(CONF_DO_NOT_DISTURB): SelectSelector(
+            SelectSelectorConfig(
+                options=["on", "off"],
+                mode=SelectSelectorMode.DROPDOWN,
+                translation_key="lookup_selector",
+            )
+        ),
+        vol.Optional(CONF_USE_ANNOUNCE): SelectSelector(
+            SelectSelectorConfig(
+                options=["on", "off"],
+                mode=SelectSelectorMode.DROPDOWN,
+                translation_key="lookup_selector",
+            )
+        ),
+        vol.Optional(CONF_MIC_UNMUTE): SelectSelector(
+            SelectSelectorConfig(
+                options=["on", "off"],
+                mode=SelectSelectorMode.DROPDOWN,
+                translation_key="lookup_selector",
+            )
+        ),
+    }
+)
+
+
+def get_developer_options_schema(
+    hass: HomeAssistant, config_entry: VAConfigEntry | None
+) -> vol.Schema:
+    """Return schema for dashboard options."""
+    return vol.Schema(
+        {
+            vol.Optional(CONF_DEVELOPER_DEVICE): SelectSelector(
                 SelectSelectorConfig(
-                    options=options,
+                    options=get_display_devices(hass, config_entry),
                     mode=SelectSelectorMode.DROPDOWN,
                 )
             ),
-            vol.Required(
-                CONF_DEV_MIMIC,
-                default=config.data.get(CONF_DEV_MIMIC, False),
-            ): bool,
+            vol.Optional(CONF_DEVELOPER_MIMIC_DEVICE): EntitySelector(
+                EntitySelectorConfig(integration=DOMAIN)
+            ),
         }
     )
+
+
+def get_suggested_option_values(config: VAConfigEntry) -> dict[str, Any]:
+    """Get suggested values for the config entry."""
+    if config.data[CONF_TYPE] == VAType.MASTER_CONFIG:
+        option_values = DEFAULT_VALUES.copy()
+        for option in DEFAULT_VALUES:
+            if config.options.get(option):
+                option_values[option] = config.options.get(option)
+        return option_values
+    return config.options
 
 
 class ViewAssistConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for View Assist."""
 
     VERSION = 1
-    MINOR_VERSION = 3
+    MINOR_VERSION = 5
 
     @staticmethod
     @callback
@@ -278,9 +375,18 @@ class ViewAssistConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Define the schema based on the selected type
         if self.type == VAType.VIEW_AUDIO:
-            data_schema = vol.Schema({**BASE_SCHEMA, **get_display_schema(self.hass)})
+            data_schema = BASE_DEVICE_SCHEMA.extend(
+                {
+                    vol.Required(CONF_DISPLAY_DEVICE): SelectSelector(
+                        SelectSelectorConfig(
+                            options=get_display_devices(self.hass),
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            )
         else:  # audio_only
-            data_schema = vol.Schema(BASE_SCHEMA)
+            data_schema = BASE_DEVICE_SCHEMA
 
         # Show the form for the selected type
         return self.async_show_form(step_id="options", data_schema=data_schema)
@@ -319,20 +425,16 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
                 menu_options=["main_config", "dashboard_options", "default_options"],
             )
         if self.va_type == VAType.MASTER_CONFIG:
-            return await self.async_step_master_config()
+            return self.async_show_menu(
+                step_id="init",
+                menu_options=[
+                    "dashboard_options",
+                    "default_options",
+                    "developer_options",
+                ],
+            )
 
         return await self.async_step_main_config()
-
-    async def async_step_master_config(self, user_input=None):
-        """Handle master config flow."""
-        if user_input is not None:
-            # This is just updating the core config so update config_entry.data
-            options = self.config_entry.options | user_input
-            return self.async_create_entry(data=options)
-
-        data_schema = vol.Schema({})
-        # Show the form for the selected type
-        return self.async_show_form(step_id="master_config", data_schema=data_schema)
 
     async def async_step_main_config(self, user_input=None):
         """Handle main config flow."""
@@ -344,263 +446,96 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
                 self.config_entry, data=user_input
             )
             return self.async_create_entry(data=None)
-        # Define the schema based on the selected type
-        BASE_OPTIONS = {
-            vol.Required(CONF_NAME, default=self.config_entry.data[CONF_NAME]): str,
-            vol.Required(
-                CONF_MIC_DEVICE, default=self.config_entry.data[CONF_MIC_DEVICE]
-            ): EntitySelector(
-                EntitySelectorConfig(
-                    filter=[
-                        EntityFilterSelectorConfig(
-                            integration="esphome", domain=ASSIST_SAT_DOMAIN
-                        ),
-                        EntityFilterSelectorConfig(
-                            integration="hassmic",
-                            domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN],
-                        ),
-                        EntityFilterSelectorConfig(
-                            integration="stream_assist",
-                            domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN],
-                        ),
-                        EntityFilterSelectorConfig(
-                            integration="wyoming", domain=ASSIST_SAT_DOMAIN
-                        ),
-                    ]
-                )
-            ),
-            vol.Required(
-                CONF_MEDIAPLAYER_DEVICE,
-                default=self.config_entry.data[CONF_MEDIAPLAYER_DEVICE],
-            ): EntitySelector(EntitySelectorConfig(domain=MEDIAPLAYER_DOMAIN)),
-            vol.Required(
-                CONF_MUSICPLAYER_DEVICE,
-                default=self.config_entry.data[CONF_MUSICPLAYER_DEVICE],
-            ): EntitySelector(EntitySelectorConfig(domain=MEDIAPLAYER_DOMAIN)),
-            vol.Optional(
-                CONF_INTENT_DEVICE,
-                description={
-                    "suggested_value": self.config_entry.data.get(CONF_INTENT_DEVICE)
-                },
-            ): EntitySelector(EntitySelectorConfig(domain=SENSOR_DOMAIN)),
-        }
 
         if self.va_type == VAType.VIEW_AUDIO:
-            data_schema = vol.Schema(
-                {**BASE_OPTIONS, **get_display_schema(self.hass, self.config_entry)}
+            data_schema = BASE_DEVICE_SCHEMA.extend(
+                {
+                    vol.Required(CONF_DISPLAY_DEVICE): SelectSelector(
+                        SelectSelectorConfig(
+                            options=get_display_devices(self.hass, self.config_entry),
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            )
+            data_schema = self.add_suggested_values_to_schema(
+                data_schema, self.config_entry.data
             )
         else:  # audio_only
-            data_schema = vol.Schema(BASE_OPTIONS)
-
-        # Show the form for the selected type
-        return self.async_show_form(step_id="main_config", data_schema=data_schema)
-
-    async def async_step_dashboard_options(self, user_input=None):
-        """Handle dashboard options flow."""
-        if user_input is not None:
-            # This is just updating the core config so update config_entry.data
-            options = self.config_entry.options | user_input
-            return self.async_create_entry(data=options)
-
-        data_schema = vol.Schema(
-            {
-                vol.Optional(
-                    CONF_DASHBOARD,
-                    default=self.config_entry.options.get(
-                        CONF_DASHBOARD, DEFAULT_DASHBOARD
-                    ),
-                ): str,
-                vol.Optional(
-                    CONF_HOME,
-                    default=self.config_entry.options.get(CONF_HOME, DEFAULT_VIEW_HOME),
-                ): str,
-                vol.Optional(
-                    CONF_MUSIC,
-                    default=self.config_entry.options.get(
-                        CONF_MUSIC, DEFAULT_VIEW_MUSIC
-                    ),
-                ): str,
-                vol.Optional(
-                    CONF_INTENT,
-                    default=self.config_entry.options.get(
-                        CONF_INTENT, DEFAULT_VIEW_INTENT
-                    ),
-                ): str,
-                vol.Optional(
-                    CONF_BACKGROUND,
-                    default=self.config_entry.options.get(
-                        CONF_BACKGROUND, DEFAULT_VIEW_BACKGROUND
-                    ),
-                ): str,
-                vol.Optional(
-                    CONF_ROTATE_BACKGROUND,
-                    default=self.config_entry.options.get(
-                        CONF_ROTATE_BACKGROUND, DEFAULT_ROTATE_BACKGROUND
-                    ),
-                ): bool,
-                vol.Optional(
-                    CONF_ROTATE_BACKGROUND_SOURCE,
-                    default=self.config_entry.options.get(
-                        CONF_ROTATE_BACKGROUND_SOURCE,
-                        DEFAULT_ROTATE_BACKGROUND_SOURCE,
-                    ),
-                ): SelectSelector(
-                    SelectSelectorConfig(
-                        translation_key="rotate_backgound_source_selector",
-                        options=[
-                            "local_sequence",
-                            "local_random",
-                            "download",
-                            "link_to_entity",
-                        ],
-                        mode=SelectSelectorMode.LIST,
-                    )
-                ),
-                vol.Optional(
-                    CONF_ROTATE_BACKGROUND_PATH,
-                    default=self.config_entry.options.get(
-                        CONF_ROTATE_BACKGROUND_PATH,
-                        DEFAULT_ROTATE_BACKGROUND_PATH,
-                    ),
-                ): str,
-                vol.Optional(
-                    CONF_ROTATE_BACKGROUND_LINKED_ENTITY,
-                    default=self.config_entry.options.get(
-                        CONF_ROTATE_BACKGROUND_LINKED_ENTITY, vol.UNDEFINED
-                    ),
-                ): EntitySelector(
-                    EntitySelectorConfig(
-                        integration=DOMAIN,
-                        domain=SENSOR_DOMAIN,
-                        exclude_entities=[
-                            get_sensor_entity_from_instance(
-                                self.hass, self.config_entry.entry_id
-                            )
-                        ],
-                    )
-                ),
-                vol.Optional(
-                    CONF_ROTATE_BACKGROUND_INTERVAL,
-                    default=self.config_entry.options.get(
-                        CONF_ROTATE_BACKGROUND_INTERVAL,
-                        DEFAULT_ROTATE_BACKGROUND_INTERVAL,
-                    ),
-                ): int,
-                vol.Optional(
-                    CONF_ASSIST_PROMPT,
-                    default=self.config_entry.options.get(
-                        CONF_ASSIST_PROMPT, DEFAULT_ASSIST_PROMPT
-                    ),
-                ): SelectSelector(
-                    SelectSelectorConfig(
-                        translation_key="assist_prompt_selector",
-                        options=[e.value for e in VAAssistPrompt],
-                        mode=SelectSelectorMode.DROPDOWN,
-                    )
-                ),
-                vol.Optional(
-                    CONF_STATUS_ICON_SIZE,
-                    default=self.config_entry.options.get(
-                        CONF_STATUS_ICON_SIZE, DEFAULT_STATUS_ICON_SIZE
-                    ),
-                ): SelectSelector(
-                    SelectSelectorConfig(
-                        translation_key="status_icons_size_selector",
-                        options=[e.value for e in VAIconSizes],
-                        mode=SelectSelectorMode.DROPDOWN,
-                    )
-                ),
-                vol.Optional(
-                    CONF_FONT_STYLE,
-                    default=self.config_entry.options.get(
-                        CONF_FONT_STYLE, DEFAULT_FONT_STYLE
-                    ),
-                ): str,
-                vol.Optional(
-                    CONF_STATUS_ICONS,
-                    default=self.config_entry.options.get(
-                        CONF_STATUS_ICONS, DEFAULT_STATUS_ICONS
-                    ),
-                ): SelectSelector(
-                    SelectSelectorConfig(
-                        translation_key="status_icons_selector",
-                        options=[],
-                        mode=SelectSelectorMode.LIST,
-                        multiple=True,
-                        custom_value=True,
-                    )
-                ),
-                vol.Optional(
-                    CONF_USE_24H_TIME,
-                    default=self.config_entry.options.get(
-                        CONF_USE_24H_TIME, DEFAULT_USE_24H_TIME
-                    ),
-                ): bool,
-                vol.Optional(
-                    CONF_HIDE_SIDEBAR,
-                    default=self.config_entry.options.get(
-                        CONF_HIDE_SIDEBAR, DEFAULT_HIDE_SIDEBAR
-                    ),
-                ): bool,
-                vol.Optional(
-                    CONF_HIDE_HEADER,
-                    default=self.config_entry.options.get(
-                        CONF_HIDE_HEADER, DEFAULT_HIDE_HEADER
-                    ),
-                ): bool,
-            }
-        )
+            data_schema = self.add_suggested_values_to_schema(
+                BASE_DEVICE_SCHEMA, self.config_entry.data
+            )
 
         # Show the form for the selected type
         return self.async_show_form(
-            step_id="dashboard_options", data_schema=data_schema
+            step_id="main_config",
+            data_schema=data_schema,
+            description_placeholders={"name": self.config_entry.title},
+        )
+
+    async def async_step_dashboard_options(self, user_input=None):
+        """Handle dashboard options flow."""
+        data_schema = self.add_suggested_values_to_schema(
+            get_dashboard_options_schema(self.config_entry),
+            get_suggested_option_values(self.config_entry),
+        )
+
+        if user_input is not None:
+            # This is just updating the core config so update config_entry.data
+            options = self.config_entry.options | user_input
+            for o in data_schema.schema:
+                if o not in user_input:
+                    options.pop(o, None)
+            return self.async_create_entry(data=options)
+
+        # Show the form
+        return self.async_show_form(
+            step_id="dashboard_options",
+            data_schema=data_schema,
+            description_placeholders={"name": self.config_entry.title},
         )
 
     async def async_step_default_options(self, user_input=None):
         """Handle default options flow."""
+
+        data_schema = self.add_suggested_values_to_schema(
+            DEFAULT_OPTIONS_SCHEMA, get_suggested_option_values(self.config_entry)
+        )
+
         if user_input is not None:
             # This is just updating the core config so update config_entry.data
             options = self.config_entry.options | user_input
+            for o in data_schema.schema:
+                if o not in user_input:
+                    options.pop(o, None)
             return self.async_create_entry(data=options)
 
-        data_schema = vol.Schema(
-            {
-                vol.Optional(
-                    CONF_WEATHER_ENTITY,
-                    default=self.config_entry.options.get(
-                        CONF_WEATHER_ENTITY, DEFAULT_WEATHER_ENITITY
-                    ),
-                ): EntitySelector(EntitySelectorConfig(domain=WEATHER_DOMAIN)),
-                vol.Optional(
-                    CONF_MODE,
-                    default=self.config_entry.options.get(CONF_MODE, DEFAULT_MODE),
-                ): str,
-                vol.Optional(
-                    CONF_VIEW_TIMEOUT,
-                    default=self.config_entry.options.get(
-                        CONF_VIEW_TIMEOUT, DEFAULT_VIEW_TIMEOUT
-                    ),
-                ): int,
-                vol.Optional(
-                    CONF_DO_NOT_DISTURB,
-                    default=self.config_entry.options.get(
-                        CONF_DO_NOT_DISTURB, DEFAULT_DND
-                    ),
-                ): bool,
-                vol.Optional(
-                    CONF_USE_ANNOUNCE,
-                    default=self.config_entry.options.get(
-                        CONF_USE_ANNOUNCE, DEFAULT_USE_ANNOUNCE
-                    ),
-                ): bool,
-                vol.Optional(
-                    CONF_MIC_UNMUTE,
-                    default=self.config_entry.options.get(
-                        CONF_MIC_UNMUTE, DEFAULT_MIC_UNMUTE
-                    ),
-                ): bool,
-            }
+        # Show the form
+        return self.async_show_form(
+            step_id="default_options",
+            data_schema=data_schema,
+            description_placeholders={"name": self.config_entry.title},
         )
 
-        # Show the form for the selected type
-        return self.async_show_form(step_id="default_options", data_schema=data_schema)
+    async def async_step_developer_options(self, user_input=None):
+        """Handle default options flow."""
+
+        data_schema = self.add_suggested_values_to_schema(
+            get_developer_options_schema(self.hass, self.config_entry),
+            get_suggested_option_values(self.config_entry),
+        )
+
+        if user_input is not None:
+            # This is just updating the core config so update config_entry.data
+            options = self.config_entry.options | user_input
+            for o in data_schema.schema:
+                if o not in user_input:
+                    options.pop(o, None)
+            return self.async_create_entry(data=options)
+
+        # Show the form
+        return self.async_show_form(
+            step_id="developer_options",
+            data_schema=data_schema,
+            description_placeholders={"name": self.config_entry.title},
+        )

--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -69,6 +69,11 @@ from .typed import VABackgroundMode, VAConfigEntry, VAScreenMode, VATimeFormat, 
 
 _LOGGER = logging.getLogger(__name__)
 
+MASTER_FORM_DESCRIPTION = "Values here will be used when no value is set on the View Assist satellite device configuration"
+DEVICE_FORM_DESCRIPTION = (
+    "Setting values here will override the master config settings for this device"
+)
+
 BASE_DEVICE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_NAME): str,
@@ -492,7 +497,12 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
         return self.async_show_form(
             step_id="dashboard_options",
             data_schema=data_schema,
-            description_placeholders={"name": self.config_entry.title},
+            description_placeholders={
+                "name": self.config_entry.title,
+                "description": MASTER_FORM_DESCRIPTION
+                if self.config_entry.data[CONF_TYPE] == VAType.MASTER_CONFIG
+                else DEVICE_FORM_DESCRIPTION,
+            },
         )
 
     async def async_step_default_options(self, user_input=None):
@@ -514,7 +524,12 @@ class ViewAssistOptionsFlowHandler(OptionsFlow):
         return self.async_show_form(
             step_id="default_options",
             data_schema=data_schema,
-            description_placeholders={"name": self.config_entry.title},
+            description_placeholders={
+                "name": self.config_entry.title,
+                "description": MASTER_FORM_DESCRIPTION
+                if self.config_entry.data[CONF_TYPE] == VAType.MASTER_CONFIG
+                else DEVICE_FORM_DESCRIPTION,
+            },
         )
 
     async def async_step_developer_options(self, user_input=None):

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -1,10 +1,16 @@
 """Integration classes and constants."""
 
-from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_MODE
+
+from .typed import (
+    VAAssistPrompt,
+    VABackgroundMode,
+    VAIconSizes,
+    VAScreenMode,
+    VATimeFormat,
+)
 
 DOMAIN = "view_assist"
 GITHUB_REPO = "dinki/View-Assist"
@@ -53,9 +59,6 @@ JSMODULES = [
 ]
 
 
-type VAConfigEntry = ConfigEntry[RuntimeData]
-
-
 class VAMode(StrEnum):
     """View Assist modes."""
 
@@ -76,93 +79,112 @@ VAMODE_REVERTS = {
 }
 
 
-class VAType(StrEnum):
-    """Sensor type enum."""
-
-    MASTER_CONFIG = "master_config"
-    VIEW_AUDIO = "view_audio"
-    AUDIO_ONLY = "audio_only"
-
-
-class VAAssistPrompt(StrEnum):
-    """Assist prompt types enum."""
-
-    BLUR_POPUP = "blur_pop_up"
-    FLASHING_BAR = "flashing_bar"
-
-
-class VAIconSizes(StrEnum):
-    """Icon size options enum."""
-
-    SMALL = "6vw"
-    MEDIUM = "7vw"
-    LARGE = "8vw"
-
-
-class VADisplayType(StrEnum):
-    """Display types."""
-
-    BROWSERMOD = "browser_mod"
-    REMOTE_ASSIST_DISPLAY = "remote_assist_display"
-
-
 # Config keys
 CONF_MIC_DEVICE = "mic_device"
 CONF_MEDIAPLAYER_DEVICE = "mediaplayer_device"
 CONF_MUSICPLAYER_DEVICE = "musicplayer_device"
 CONF_DISPLAY_DEVICE = "display_device"
 CONF_INTENT_DEVICE = "intent_device"
+
 CONF_DASHBOARD = "dashboard"
 CONF_HOME = "home"
 CONF_INTENT = "intent"
 CONF_MUSIC = "music"
+CONF_BACKGROUND_SETTINGS = "background_settings"
+CONF_BACKGROUND_MODE = "background_mode"
 CONF_BACKGROUND = "background"
+CONF_ROTATE_BACKGROUND_PATH = "rotate_background_path"
+CONF_ROTATE_BACKGROUND_LINKED_ENTITY = "rotate_background_linked_entity"
+CONF_ROTATE_BACKGROUND_INTERVAL = "rotate_background_interval"
+
+CONF_DISPLAY_SETTINGS = "display_settings"
 CONF_ASSIST_PROMPT = "assist_prompt"
 CONF_STATUS_ICON_SIZE = "status_icons_size"
 CONF_FONT_STYLE = "font_style"
 CONF_STATUS_ICONS = "status_icons"
-CONF_USE_24H_TIME = "use_24_hour_time"
+CONF_TIME_FORMAT = "time_format"
+CONF_SCREEN_MODE = "screen_mode"
+
 CONF_WEATHER_ENTITY = "weather_entity"
 CONF_VIEW_TIMEOUT = "view_timeout"
 CONF_DO_NOT_DISTURB = "do_not_disturb"
 CONF_USE_ANNOUNCE = "use_announce"
 CONF_MIC_UNMUTE = "micunmute"
+
+
+CONF_DEVELOPER_DEVICE = "developer_device"
+CONF_DEVELOPER_MIMIC_DEVICE = "developer_mimic_device"
+
+
+# Legacy
+CONF_MIC_TYPE = "mic_type"
+CONF_USE_24H_TIME = "use_24_hour_time"
 CONF_DEV_MIMIC = "dev_mimic"
 CONF_HIDE_HEADER = "hide_header"
 CONF_HIDE_SIDEBAR = "hide_sidebar"
 CONF_ROTATE_BACKGROUND = "rotate_background"
 CONF_ROTATE_BACKGROUND_SOURCE = "rotate_background_source"
-CONF_ROTATE_BACKGROUND_PATH = "rotate_background_path"
-CONF_ROTATE_BACKGROUND_LINKED_ENTITY = "rotate_background_linked_entity"
-CONF_ROTATE_BACKGROUND_INTERVAL = "rotate_background_interval"
-CONF_MIC_TYPE = "mic_type"
+
+
+DEFAULT_VALUES = {
+    # Dashboard options
+    CONF_DASHBOARD: "/view-assist",
+    CONF_HOME: "/view-assist/clock",
+    CONF_MUSIC: "/view-assist/music",
+    CONF_INTENT: "/view-assist/intent",
+    CONF_BACKGROUND_SETTINGS: {
+        CONF_BACKGROUND_MODE: VABackgroundMode.DEFAULT_BACKGROUND,
+        CONF_BACKGROUND: "/view_assist/dashboard/background.jpg",
+        CONF_ROTATE_BACKGROUND_PATH: f"{IMAGE_PATH}/backgrounds",
+        CONF_ROTATE_BACKGROUND_LINKED_ENTITY: "",
+        CONF_ROTATE_BACKGROUND_INTERVAL: 60,
+    },
+    CONF_DISPLAY_SETTINGS: {
+        CONF_ASSIST_PROMPT: VAAssistPrompt.BLUR_POPUP,
+        CONF_STATUS_ICON_SIZE: VAIconSizes.LARGE,
+        CONF_FONT_STYLE: "Roboto",
+        CONF_STATUS_ICONS: [],
+        CONF_TIME_FORMAT: VATimeFormat.HOUR_12,
+        CONF_SCREEN_MODE: VAScreenMode.HIDE_HEADER_SIDEBAR,
+    },
+    # Default options
+    CONF_WEATHER_ENTITY: "weather.home",
+    CONF_MODE: VAMode.NORMAL,
+    CONF_VIEW_TIMEOUT: 20,
+    CONF_DO_NOT_DISTURB: "off",
+    CONF_USE_ANNOUNCE: "off",
+    CONF_MIC_UNMUTE: "off",
+    # Default developer otions
+    CONF_DEVELOPER_DEVICE: "",
+    CONF_DEVELOPER_MIMIC_DEVICE: "",
+}
 
 # Config default values
 DEFAULT_NAME = "View Assist"
-DEFAULT_TYPE = VAType.VIEW_AUDIO
-DEFAULT_DASHBOARD = "/view-assist"
-DEFAULT_VIEW_HOME = "/view-assist/clock"
-DEFAULT_VIEW_MUSIC = "/view-assist/music"
-DEFAULT_VIEW_INTENT = "/view-assist/intent"
+DEFAULT_TYPE = "view_audio"
+# DEFAULT_DASHBOARD = "/view-assist"
+# DEFAULT_VIEW_HOME = "/view-assist/clock"
+# DEFAULT_VIEW_MUSIC = "/view-assist/music"
+# DEFAULT_VIEW_INTENT = "/view-assist/intent"
 DEFAULT_VIEW_INFO = "info"
-DEFAULT_VIEW_BACKGROUND = "/view_assist/dashboard/background.jpg"
-DEFAULT_ASSIST_PROMPT = VAAssistPrompt.BLUR_POPUP
-DEFAULT_STATUS_ICON_SIZE = VAIconSizes.LARGE
-DEFAULT_FONT_STYLE = "Roboto"
-DEFAULT_STATUS_ICONS = []
-DEFAULT_USE_24H_TIME = False
-DEFAULT_WEATHER_ENITITY = "weather.home"
-DEFAULT_MODE = "normal"
-DEFAULT_VIEW_TIMEOUT = 20
-DEFAULT_DND = False
-DEFAULT_USE_ANNOUNCE = True
-DEFAULT_MIC_UNMUTE = False
-DEFAULT_HIDE_SIDEBAR = True
-DEFAULT_HIDE_HEADER = True
-DEFAULT_ROTATE_BACKGROUND = False
-DEFAULT_ROTATE_BACKGROUND_SOURCE = "local_sequence"
-DEFAULT_ROTATE_BACKGROUND_PATH = f"{IMAGE_PATH}/backgrounds"
-DEFAULT_ROTATE_BACKGROUND_INTERVAL = 60
+# DEFAULT_VIEW_BACKGROUND = "/view_assist/dashboard/background.jpg"
+# DEFAULT_ASSIST_PROMPT = VAAssistPrompt.BLUR_POPUP
+# DEFAULT_STATUS_ICON_SIZE = VAIconSizes.LARGE
+# DEFAULT_FONT_STYLE = "Roboto"
+# DEFAULT_STATUS_ICONS = []
+# DEFAULT_USE_24H_TIME = False
+# DEFAULT_WEATHER_ENITITY = "weather.home"
+# DEFAULT_MODE = "normal"
+# DEFAULT_VIEW_TIMEOUT = 20
+# DEFAULT_DND = "off"
+# DEFAULT_USE_ANNOUNCE = "off"
+# DEFAULT_MIC_UNMUTE = "off"
+# DEFAULT_HIDE_SIDEBAR = True
+# DEFAULT_HIDE_HEADER = True
+# DEFAULT_ROTATE_BACKGROUND = False
+# DEFAULT_ROTATE_BACKGROUND_SOURCE = "local_sequence"
+# DEFAULT_ROTATE_BACKGROUND_PATH = f"{IMAGE_PATH}/backgrounds"
+# DEFAULT_ROTATE_BACKGROUND_INTERVAL = 60
 
 # Service attributes
 ATTR_EVENT_NAME = "event_name"
@@ -184,61 +206,6 @@ ATTR_MAX_REPEATS = "max_repeats"
 VA_ATTRIBUTE_UPDATE_EVENT = "va_attr_update_event_{}"
 VA_BACKGROUND_UPDATE_EVENT = "va_background_update_{}"
 CC_CONVERSATION_ENDED_EVENT = f"{CUSTOM_CONVERSATION_DOMAIN}_conversation_ended"
-
-
-class RuntimeData:
-    """Class to hold your data."""
-
-    def __init__(self) -> None:
-        """Initialise runtime data."""
-
-        # Default config
-        self.type: VAType | None = None
-        self.name: str = ""
-        self.mic_device: str = ""
-        self.mediaplayer_device: str = ""
-        self.musicplayer_device: str = ""
-        self.display_device: str = ""
-        self.intent_device: str = ""
-        self.dev_mimic: bool = False
-
-        # Dashboard options
-        self.dashboard: str = DEFAULT_DASHBOARD
-        self.home: str = DEFAULT_VIEW_HOME
-        self.music: str = DEFAULT_VIEW_MUSIC
-        self.intent: str = DEFAULT_VIEW_INTENT
-        self.background: str = DEFAULT_VIEW_BACKGROUND
-        self.rotate_background: bool = False
-        self.rotate_background_source: str = "local"
-        self.rotate_background_path: str = ""
-        self.rotate_background_linked_entity: str = ""
-        self.rotate_background_interval: int = 60
-        self.assist_prompt: VAAssistPrompt = DEFAULT_ASSIST_PROMPT
-        self.status_icons_size: VAIconSizes = DEFAULT_STATUS_ICON_SIZE
-        self.font_style: str = DEFAULT_FONT_STYLE
-        self.status_icons: list[str] = DEFAULT_STATUS_ICONS
-        self.use_24_hour_time: bool = DEFAULT_USE_24H_TIME
-
-        # Default options
-        self.weather_entity: str = DEFAULT_WEATHER_ENITITY
-        self.mode: str = DEFAULT_MODE
-        self.view_timeout: int = DEFAULT_VIEW_TIMEOUT
-        self.hide_sidebar: bool = DEFAULT_HIDE_SIDEBAR
-        self.hide_header: bool = DEFAULT_HIDE_HEADER
-        self.do_not_disturb: bool = DEFAULT_DND
-        self.use_announce: bool = DEFAULT_USE_ANNOUNCE
-        self.mic_unmute: bool = DEFAULT_MIC_UNMUTE
-
-        # Extra data for holding key/value pairs passed in by set_state service call
-        self.extra_data: dict[str, Any] = {}
-
-
-@dataclass
-class VAEvent:
-    """View Assist event."""
-
-    event_name: str
-    payload: dict | None = None
 
 
 # TODO: Remove this when BP/Views updated

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -162,29 +162,8 @@ DEFAULT_VALUES = {
 # Config default values
 DEFAULT_NAME = "View Assist"
 DEFAULT_TYPE = "view_audio"
-# DEFAULT_DASHBOARD = "/view-assist"
-# DEFAULT_VIEW_HOME = "/view-assist/clock"
-# DEFAULT_VIEW_MUSIC = "/view-assist/music"
-# DEFAULT_VIEW_INTENT = "/view-assist/intent"
 DEFAULT_VIEW_INFO = "info"
-# DEFAULT_VIEW_BACKGROUND = "/view_assist/dashboard/background.jpg"
-# DEFAULT_ASSIST_PROMPT = VAAssistPrompt.BLUR_POPUP
-# DEFAULT_STATUS_ICON_SIZE = VAIconSizes.LARGE
-# DEFAULT_FONT_STYLE = "Roboto"
-# DEFAULT_STATUS_ICONS = []
-# DEFAULT_USE_24H_TIME = False
-# DEFAULT_WEATHER_ENITITY = "weather.home"
-# DEFAULT_MODE = "normal"
-# DEFAULT_VIEW_TIMEOUT = 20
-# DEFAULT_DND = "off"
-# DEFAULT_USE_ANNOUNCE = "off"
-# DEFAULT_MIC_UNMUTE = "off"
-# DEFAULT_HIDE_SIDEBAR = True
-# DEFAULT_HIDE_HEADER = True
-# DEFAULT_ROTATE_BACKGROUND = False
-# DEFAULT_ROTATE_BACKGROUND_SOURCE = "local_sequence"
-# DEFAULT_ROTATE_BACKGROUND_PATH = f"{IMAGE_PATH}/backgrounds"
-# DEFAULT_ROTATE_BACKGROUND_INTERVAL = 60
+
 
 # Service attributes
 ATTR_EVENT_NAME = "event_name"

--- a/custom_components/view_assist/dashboard.py
+++ b/custom_components/view_assist/dashboard.py
@@ -43,10 +43,9 @@ from .const import (
     GITHUB_REPO,
     GITHUB_TOKEN_FILE,
     VIEWS_DIR,
-    VAConfigEntry,
-    VAEvent,
 )
 from .helpers import differ_to_json, json_to_dictdiffer
+from .typed import VAConfigEntry, VAEvent
 from .utils import dictdiff
 from .websocket import MockWSConnection
 

--- a/custom_components/view_assist/http_url.py
+++ b/custom_components/view_assist/http_url.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, URL_BASE, VA_SUB_DIRS, VAConfigEntry
+from .const import DOMAIN, URL_BASE, VA_SUB_DIRS
+from .typed import VAConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/view_assist/services.py
+++ b/custom_components/view_assist/services.py
@@ -38,7 +38,6 @@ from .const import (
     ATTR_TIMER_ID,
     ATTR_TYPE,
     DOMAIN,
-    VAConfigEntry,
 )
 from .dashboard import (
     DASHBOARD_MANAGER,
@@ -48,6 +47,7 @@ from .dashboard import (
 )
 from .helpers import get_mimic_entity_id
 from .timers import TIMERS, VATimers, decode_time_sentence
+from .typed import VAConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/view_assist/translations/en.json
+++ b/custom_components/view_assist/translations/en.json
@@ -14,7 +14,7 @@
     "step": {
       "master_config": {
         "title": "Master Configuration",
-        "description": "This adds a master configuration instance of View Assist\n\nIt must be added before you can setup any View Assist device instances if a new install or any more View Assist devices instances if an existing install\n\nPlease restart Home Assistant once you have added this.  You may also need to refresh your Home Assistant devices to enable the full functionality"
+        "description": "This adds a master configuration instance of View Assist\n\nIt must be added before you can setup any View Assist device instances if a new install or any more View Assist devices instances if an existing install\n\nYou may need to refresh any existing View Assist devices to enable the full functionality"
       },
       "options": {
         "title": "Configure a View Assist device",
@@ -41,10 +41,6 @@
   },
   "options": {
     "step": {
-      "master_config": {
-        "title": "Master Configuration",
-        "description": "Master configuration options will be available here in future versions"
-      },
       "init": {
         "title": "Configuration",
         "description": "Select which options to amend",
@@ -79,7 +75,7 @@
       },
       "dashboard_options": {
         "title": "{name} Dashboard Options",
-        "description": "",
+        "description": "{description}",
         "data": {
           "dashboard": "Dashboard",
           "home": "Home screen",
@@ -134,7 +130,7 @@
       },
       "default_options": {
         "title": "{name} Default Options",
-        "description": "Setting values here will override the master config settings for this device",
+        "description": "{description}",
         "data": {
           "weather_entity": "Weather entity to use for conditons display",
           "mic_type": "The integration handling microphone input",

--- a/custom_components/view_assist/translations/en.json
+++ b/custom_components/view_assist/translations/en.json
@@ -46,16 +46,17 @@
         "description": "Master configuration options will be available here in future versions"
       },
       "init": {
-        "title": "Reconfigure device",
+        "title": "Configuration",
         "description": "Select which options to amend",
         "menu_options": {
           "main_config": "Core Device Configuration",
           "dashboard_options": "Dashboard Options",
-          "default_options": "Default Options"
+          "default_options": "Default Options",
+          "developer_options": "Developer Options"
         }
       },
       "main_config": {
-        "title": "Core Device Configuration",
+        "title": "{name} Core Device Configuration",
         "description": "",
         "data": {
           "name": "Satellite Name",
@@ -77,54 +78,69 @@
         }
       },
       "dashboard_options": {
-        "title": "Dashboard Options",
+        "title": "{name} Dashboard Options",
         "description": "",
         "data": {
           "dashboard": "Dashboard",
           "home": "Home screen",
           "music": "Music view",
-          "intent": "Intent view",
-          "background": "Default background",
-          "rotate_background": "Enable image rotation",
-          "rotate_background_source": "Image source",
-          "rotate_background_path": "Image path",
-          "rotate_background_linked_entity": "Linked entity",
-          "rotate_background_interval": "Rotation interval",
-          "assist_prompt": "Assist prompt",
-          "status_icons_size": "Status icon size",
-          "font_style": "Font style",
-          "status_icons": "Launch icons",
-          "use_24_hour_time": "Use 24h time",
-          "hide_sidebar": "Hide sidemenu",
-          "hide_header": "Hide header bar"
+          "intent": "Intent view"
         },
         "data_description": {
           "dashboard": "The base dashboard for View Assist (do not include trailing slash)",
           "home": "The screen to return to after timeout",
           "music": "The view to return to when in music mode",
-          "intent": "The view to display for default HA actions for displaying those entities",
-          "background": "The default background image url",
-          "rotate_background_path": "Load images from in local mode, save images to in download mode, ignored in linked mode.  A path under config/view_assist",
-          "rotate_background_linked_entity": "View Assist entity to link the background to",
-          "rotate_background_interval": "Interval in minutes to rotate the background",
-          "assist_prompt": "The Assist notification prompt style to use for wake word detection and intent processing",
-          "status_icons_size": "Size of the icons in the status icon display",
-          "font_style": "The default font to use for this satellite device. Font name must match perfectly and be available",
-          "status_icons": "Advanced option! List of custom launch icons to set on start up. Do not change this if you do not know what you are doing",
-          "use_24_hour_time": "Sets clock display to 24 hour time when enabled",
-          "hide_sidebar": "Hide the sidemenu on the display via View Assist",
-          "hide_header": "Hide the header on the display via View Assist"
+          "intent": "The view to display for default HA actions for displaying those entities"
+        },
+        "sections": {
+          "background_settings": {
+            "name": "Background Settings",
+            "description": "Options for the background image",
+            "data": {
+              "background_mode": "Background image source",
+              "background": "Default background",
+              "rotate_background_path": "Image path",
+              "rotate_background_linked_entity": "Linked entity",
+              "rotate_background_interval": "Rotation interval"
+            },
+            "data_description": {
+              "background": "The default background image url",
+              "rotate_background_path": "Load images from in local mode, save images to in download mode, ignored in linked mode.  A path under config/view_assist",
+              "rotate_background_linked_entity": "View Assist entity to link the background to",
+              "rotate_background_interval": "Interval in minutes to rotate the background"
+            }
+          },
+          "display_settings": {
+            "name": "Display Settings",
+            "description": "Options for the display device",
+            "data": {
+              "assist_prompt": "Assist prompt",
+              "status_icons_size": "Status icon size",
+              "font_style": "Font style",
+              "status_icons": "Launch icons",
+              "time_format": "Time format",
+              "screen_mode": "Show/hide header and sidebar"
+            },
+            "data_description": {
+              "assist_prompt": "The Assist notification prompt style to use for wake word detection and intent processing",
+              "status_icons_size": "Size of the icons in the status icon display",
+              "font_style": "The default font to use for this satellite device. Font name must match perfectly and be available",
+              "status_icons": "Advanced option! List of custom launch icons to set on start up. Do not change this if you do not know what you are doing",
+              "time_format": "Sets clock display time format",
+              "screen_mode": "Show or hide the header and sidebar"
+            }
+          }
         }
       },
       "default_options": {
-        "title": "Default Options",
-        "description": "",
+        "title": "{name} Default Options",
+        "description": "Setting values here will override the master config settings for this device",
         "data": {
           "weather_entity": "Weather entity to use for conditons display",
           "mic_type": "The integration handling microphone input",
           "mode": "Default Mode",
           "view_timeout": "View Timeout",
-          "do_not_disturb": "Do not disturb default on",
+          "do_not_disturb": "Enable do not disturb at startup",
           "use_announce": "Disable announce on this device",
           "micunmute": "Unmute microphone on HA start/restart"
         },
@@ -134,6 +150,17 @@
           "do_not_disturb": "Default state for do not disturb mode on HA restart",
           "use_announce": "Some media player devices, like BrowserMod, cannot use the Home Assistant announce feature while media is playing. This option allows for turning off announce messages if problems arise. Default is on.",
           "micunmute": "Helpful for Stream Assist devices"
+        }
+      },
+      "developer_options": {
+        "title": "{name} Developer Options",
+        "data": {
+          "developer_device": "Developer device",
+          "developer_mimic_device": "Mimic device"
+        },
+        "data_description": {
+          "developer_device": "The browser id of the device you wish to use for development",
+          "developer_mimic_device": "The device to mimic for development"
         }
       }
     }
@@ -174,10 +201,23 @@
     },
     "rotate_backgound_source_selector": {
       "options": {
-        "local_sequence": "Local file path sequence",
-        "local_random": "Local file path random",
-        "download": "Download random image from Unsplash",
-        "link_to_entity": "Linked to another View Assist device"
+        "default_background": "Default background",
+        "local_sequence": "Sequenced image from local file path",
+        "local_random": "Random image from local file path",
+        "download": "Random image from unsplash.com",
+        "link_to_entity": "Mirror another View Assist device"
+      }
+    },
+    "lookup_selector": {
+      "options": {
+        "hour_12": "12 Hour",
+        "hour_24": "24 Hour",
+        "on": "On",
+        "off": "Off",
+        "hide_header_sidebar": "Hide header and side menu",
+        "hide_header": "Hide header",
+        "hide_sidebar": "Hide side menu",
+        "no_hide": "Do not hide elements"
       }
     }
   }

--- a/custom_components/view_assist/typed.py
+++ b/custom_components/view_assist/typed.py
@@ -1,0 +1,168 @@
+"""Types for View Assist."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+
+type VAConfigEntry = ConfigEntry[MasterConfigRuntimeData | DeviceRuntimeData]
+
+
+class VAType(StrEnum):
+    """Sensor type enum."""
+
+    MASTER_CONFIG = "master_config"
+    VIEW_AUDIO = "view_audio"
+    AUDIO_ONLY = "audio_only"
+
+
+class VATimeFormat(StrEnum):
+    """Time format enum."""
+
+    HOUR_12 = "hour_12"
+    HOUR_24 = "hour_24"
+
+
+class VAScreenMode(StrEnum):
+    """Screen mode enum."""
+
+    NO_HIDE = "no_hide"
+    HIDE_HEADER = "hide_header"
+    HIDE_SIDEBAR = "hide_sidebar"
+    HIDE_HEADER_SIDEBAR = "hide_header_sidebar"
+
+
+class VAAssistPrompt(StrEnum):
+    """Assist prompt types enum."""
+
+    BLUR_POPUP = "blur_pop_up"
+    FLASHING_BAR = "flashing_bar"
+
+
+class VAIconSizes(StrEnum):
+    """Icon size options enum."""
+
+    SMALL = "6vw"
+    MEDIUM = "7vw"
+    LARGE = "8vw"
+
+
+class VADisplayType(StrEnum):
+    """Display types."""
+
+    BROWSERMOD = "browser_mod"
+    REMOTE_ASSIST_DISPLAY = "remote_assist_display"
+
+
+class VABackgroundMode(StrEnum):
+    """Background mode enum."""
+
+    DEFAULT_BACKGROUND = "default_background"
+    LOCAL_SEQUENCE = "local_sequence"
+    LOCAL_RANDOM = "local_random"
+    DOWNLOAD_RANDOM = "download"
+    LINKED = "link_to_entity"
+
+
+@dataclass
+class DeviceCoreConfig:
+    """Class to hold core config data."""
+
+    type: VAType | None = None
+    name: str | None = None
+    mic_device: str | None = None
+    mediaplayer_device: str | None = None
+    musicplayer_device: str | None = None
+    intent_device: str | None = None
+    display_device: str | None = None
+    dev_mimic: bool | None = None
+
+
+@dataclass
+class BackgroundConfig:
+    "Background settings class."
+
+    background_mode: str | None = None
+    background: str | None = None
+    rotate_background_path: str | None = None
+    rotate_background_linked_entity: str | None = None
+    rotate_background_interval: int | None = None
+
+
+@dataclass
+class DisplayConfig:
+    """Display settings class."""
+
+    assist_prompt: VAAssistPrompt | None = None
+    status_icons_size: VAIconSizes | None = None
+    font_style: str | None = None
+    status_icons: list[str] = field(default_factory=list)
+    time_format: VATimeFormat | None = None
+    screen_mode: VAScreenMode | None = None
+
+
+@dataclass
+class DashboardConfig:
+    """Class to hold dashboard config data."""
+
+    dashboard: str | None = None
+    home: str | None = None
+    music: str | None = None
+    intent: str | None = None
+    background_settings: BackgroundConfig = field(default_factory=BackgroundConfig)
+    display_settings: DisplayConfig = field(default_factory=DisplayConfig)
+
+
+@dataclass
+class DefaultConfig:
+    """Class to hold default config data."""
+
+    weather_entity: str | None = None
+    mode: str | None = None
+    view_timeout: int | None = None
+    do_not_disturb: bool | None = None
+    use_announce: bool | None = None
+    mic_unmute: bool | None = None
+
+
+@dataclass
+class DeveloperConfig:
+    """Class to hold developer config data."""
+
+    developer_device: str | None = None
+    developer_mimic_device: str | None = None
+
+
+class MasterConfigRuntimeData:
+    """Class to hold master config data."""
+
+    def __init__(self) -> None:
+        """Initialize runtime data."""
+        self.dashboard: DashboardConfig = DashboardConfig()
+        self.default: DefaultConfig = DefaultConfig()
+        self.developer_settings: DeveloperConfig = DeveloperConfig()
+        # Extra data for holding key/value pairs passed in by set_state service call
+        self.extra_data: dict[str, Any] = {}
+
+
+class DeviceRuntimeData:
+    """Class to hold runtime data."""
+
+    def __init__(self) -> None:
+        """Initialize runtime data."""
+        self.core: DeviceCoreConfig = DeviceCoreConfig()
+        self.dashboard: DashboardConfig = DashboardConfig()
+        self.default: DefaultConfig = DefaultConfig()
+        # Extra data for holding key/value pairs passed in by set_state service call
+        self.extra_data: dict[str, Any] = {}
+
+
+@dataclass
+class VAEvent:
+    """View Assist event."""
+
+    event_name: str
+    payload: dict | None = None

--- a/custom_components/view_assist/websocket.py
+++ b/custom_components/view_assist/websocket.py
@@ -17,7 +17,7 @@ from homeassistant.components.websocket_api import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DOMAIN, VAEvent
+from .const import DOMAIN
 from .helpers import (
     get_config_entry_by_entity_id,
     get_device_id_from_entity_id,
@@ -25,6 +25,7 @@ from .helpers import (
     get_mimic_entity_id,
 )
 from .timers import TIMERS, VATimers
+from .typed import VAEvent, VAScreenMode
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -101,7 +102,7 @@ async def async_register_websockets(hass: HomeAssistant):  # noqa: C901
             entity = get_entity_id_by_browser_id(hass, browser_id)
 
             if not entity:
-                if entity := get_mimic_entity_id(hass):
+                if entity := get_mimic_entity_id(hass, browser_id):
                     mimic = True
             return entity, mimic
 
@@ -291,28 +292,30 @@ async def async_register_websockets(hass: HomeAssistant):  # noqa: C901
                     "browser_id": browser_id,
                     "entity_id": entity_id,
                     "mimic_device": mimic,
-                    "name": data.name,
-                    "mic_entity_id": data.mic_device,
+                    "name": data.core.name,
+                    "mic_entity_id": data.core.mic_device,
                     "mic_device_id": get_device_id_from_entity_id(
-                        hass, data.mic_device
+                        hass, data.core.mic_device
                     ),
-                    "mediaplayer_entity_id": data.mediaplayer_device,
+                    "mediaplayer_entity_id": data.core.mediaplayer_device,
                     "mediaplayer_device_id": get_device_id_from_entity_id(
-                        hass, data.mediaplayer_device
+                        hass, data.core.mediaplayer_device
                     ),
-                    "musicplayer_entity_id": data.musicplayer_device,
+                    "musicplayer_entity_id": data.core.musicplayer_device,
                     "musicplayer_device_id": get_device_id_from_entity_id(
-                        hass, data.musicplayer_device
+                        hass, data.core.musicplayer_device
                     ),
-                    "display_device_id": data.display_device,
+                    "display_device_id": data.core.display_device,
                     "timers": timer_info,
-                    "background": data.background,
-                    "dashboard": data.dashboard,
-                    "home": data.home,
-                    "music": data.music,
-                    "intent": data.intent,
-                    "hide_sidebar": data.hide_sidebar,
-                    "hide_header": data.hide_header,
+                    "background": data.dashboard.background_settings.background,
+                    "dashboard": data.dashboard.dashboard,
+                    "home": data.dashboard.home,
+                    "music": data.dashboard.music,
+                    "intent": data.dashboard.intent,
+                    "hide_sidebar": data.dashboard.display_settings.screen_mode
+                    in [VAScreenMode.HIDE_HEADER_SIDEBAR, VAScreenMode.HIDE_SIDEBAR],
+                    "hide_header": data.dashboard.display_settings.screen_mode
+                    in [VAScreenMode.HIDE_HEADER_SIDEBAR, VAScreenMode.HIDE_HEADER],
                 }
             except Exception:  # noqa: BLE001
                 output = {}


### PR DESCRIPTION
This PR provides for the concept of master config default settings.

**WARNING**: Once applied, you cannot downgrade the version without removing all entries and starting again.

There are a lot of changes in this as listed below, split by UI and code but it should be a simple upgrade for existing users.

Any existing setup will be migrated to the new config schema when loading for the first time after upgrade and no user action is required.

However, existing config on the VA device will be migrated and exist on the new VA device.  Users, wanting to use the new default configuration settings, will need to delete the values in the fields on their VA device configurations.

This will probably need some explaining but it should all continue to work as it did previously.

## UI changes

### Master config configure menu
Master config instance now contains 3 menu options when configuring.
  - Dashboard options - default dashboard options for all VA devices
  - Default options - default default options for all VA devices
  - Developer options - new way to set the developer mimic device - see developer mimic device

### Configuration menu layouts (master config and VA device config)
  - Dashboard options - the background settings and display settings groups of settings have been grouped under sections on the  form.
  - All boolean (checkboxes) form elements have been replaced with drop down menus to allow the 3rd state of blank - thus allowing following of the master config
      - Background settings have changed to select a background mode, rather than enable/disable image rotation.
      - Use 24h time is now a time format dropdown under display settings
      - Show/hide header/sidebar is now a dropdown under display settings
      - enable DND at startup, Disable announce and unmute mic on startup are all now dropdown menus with On/Off/Blank as options

### Developer Mimic Device
The original mimic device tick box on a VA device config and been removed and replaced with a menu option in the master config instance.  This requires that a browser id of the development browser is selected, along with a VA device to mimic.

This has been changed to make it less confusing when setting up new devices.  They will no longer show as the mimic device as they did previously, but now show correctly as a non registered device and show its browser id on the VA dashboard views.

## Code changes

### Runtime data
Whilst there are many changes in the code, the main relevant changes are in the structure of runtime data.  This has been sub divided into core, dashboard, default and developer.  See typed.py DeviceRuntimeData and MasterConfigRuntimeData for this new structure.  All code has been updated to reflect this change.

### Source of config values
The following is the order of how runtime values are defined for a VA device.  The value is derived from the first match in the list
1. Device has its own setting for that parameter
2. Parameter has a value in master config (will not be the case unless saved from master config configuration)
3. Uses default value as defined in const.py


## Testing Notes
1. After upgrade, you need to f5 the browser to pick up the new config form field names - HA feature!
2. Need to test that VA device settings correctly migrated and remain the same (or equivalent value) in the new layout
3. Need to test that blanking out a setting on a VA device remains and then applies master config to the device
4. Need to test changing master config updates all devices without reboot/refresh
