### PR TITLE
added: volume ducking support - issue #79

### DIFF
--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -37,6 +37,7 @@ from .const import (
     CONF_DISPLAY_DEVICE,
     CONF_DISPLAY_SETTINGS,
     CONF_DO_NOT_DISTURB,
+    CONF_DUCKING_VOLUME,
     CONF_FONT_STYLE,
     CONF_HOME,
     CONF_INTENT,
@@ -270,6 +271,14 @@ DEFAULT_OPTIONS_SCHEMA = vol.Schema(
                 options=["on", "off"],
                 mode=SelectSelectorMode.DROPDOWN,
                 translation_key="lookup_selector",
+            )
+        ),
+        vol.Optional(CONF_DUCKING_VOLUME): NumberSelector(
+            NumberSelectorConfig(
+                min=0,
+                max=100,
+                step=1.0,
+                mode=NumberSelectorMode.BOX,
             )
         ),
     }

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -43,6 +43,7 @@ CYCLE_VIEWS = ["music", "info", "weather", "clock"]
 BROWSERMOD_DOMAIN = "browser_mod"
 REMOTE_ASSIST_DISPLAY_DOMAIN = "remote_assist_display"
 CUSTOM_CONVERSATION_DOMAIN = "custom_conversation"
+HASSMIC_DOMAIN = "hassmic"
 USE_VA_NAVIGATION_FOR_BROWSERMOD = True
 
 IMAGE_PATH = "images"
@@ -110,6 +111,7 @@ CONF_VIEW_TIMEOUT = "view_timeout"
 CONF_DO_NOT_DISTURB = "do_not_disturb"
 CONF_USE_ANNOUNCE = "use_announce"
 CONF_MIC_UNMUTE = "micunmute"
+CONF_DUCKING_VOLUME = "ducking_volume"
 
 
 CONF_DEVELOPER_DEVICE = "developer_device"
@@ -154,6 +156,7 @@ DEFAULT_VALUES = {
     CONF_DO_NOT_DISTURB: "off",
     CONF_USE_ANNOUNCE: "off",
     CONF_MIC_UNMUTE: "off",
+    CONF_DUCKING_VOLUME: 2,
     # Default developer otions
     CONF_DEVELOPER_DEVICE: "",
     CONF_DEVELOPER_MIMIC_DEVICE: "",

--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -6,6 +6,8 @@ from datetime import datetime as dt
 import logging
 import random
 
+from homeassistant.components.assist_satellite.entity import AssistSatelliteState
+from homeassistant.components.media_player import MediaPlayerState
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_MODE
 from homeassistant.core import (
@@ -30,6 +32,7 @@ from .const import (
     CYCLE_VIEWS,
     DEFAULT_VIEW_INFO,
     DOMAIN,
+    HASSMIC_DOMAIN,
     REMOTE_ASSIST_DISPLAY_DOMAIN,
     USE_VA_NAVIGATION_FOR_BROWSERMOD,
     VA_ATTRIBUTE_UPDATE_EVENT,
@@ -39,10 +42,12 @@ from .const import (
 from .helpers import (
     async_get_download_image,
     async_get_filesystem_images,
+    get_config_entry_by_entity_id,
     get_device_name_from_id,
     get_display_type_from_browser_id,
     get_entity_attribute,
     get_entity_id_from_conversation_device_id,
+    get_hassmic_pipeline_status_entity_id,
     get_key,
     get_mute_switch_entity_id,
     get_revert_settings_for_mode,
@@ -67,10 +72,7 @@ class EntityListeners:
         self.cycle_view_task: Task | None = None
         self.rotate_background_task: Task | None = None
 
-        # Add microphone mute switch listener
-        mute_switch = get_mute_switch_entity_id(
-            hass, config_entry.runtime_data.core.mic_device
-        )
+        self.music_player_volume: float | None = None
 
         # Add browser navigate service listener
         config_entry.async_on_unload(
@@ -89,7 +91,37 @@ class EntityListeners:
             )
         )
 
-        # Add mic mute switch listener
+        # Add mic device/wake word entity listening listner for volume ducking
+        if config_entry.runtime_data.default.ducking_volume is not None:
+            mic_integration = get_config_entry_by_entity_id(
+                self.hass, self.config_entry.runtime_data.core.mic_device
+            ).domain
+            if mic_integration == HASSMIC_DOMAIN:
+                entity_id = get_hassmic_pipeline_status_entity_id(
+                    hass, self.config_entry.runtime_data.core.mic_device
+                )
+            else:
+                entity_id = self.config_entry.runtime_data.core.mic_device
+
+            if entity_id:
+                _LOGGER.debug("Listening for mic device %s", entity_id)
+                config_entry.async_on_unload(
+                    async_track_state_change_event(
+                        hass,
+                        entity_id,
+                        self._async_on_mic_state_change,
+                    )
+                )
+            else:
+                _LOGGER.warning(
+                    "Unable to find entity for pipeline status for %s",
+                    self.config_entry.runtime_data.core.mic_device,
+                )
+
+        # Add microphone mute switch listener
+        mute_switch = get_mute_switch_entity_id(
+            hass, config_entry.runtime_data.core.mic_device
+        )
         if mute_switch:
             config_entry.async_on_unload(
                 async_track_state_change_event(
@@ -400,6 +432,96 @@ class EntityListeners:
     # ---------------------------------------------------------------------------------------
     # Actions for monitoring changes to external entities
     # ---------------------------------------------------------------------------------------
+
+    async def _async_on_mic_state_change(
+        self, event: Event[EventStateChangedData]
+    ) -> None:
+        """Handle mic state change event for volume ducking."""
+
+        # If not change to mic state, exit function
+        if (
+            not event.data.get("old_state")
+            or event.data["old_state"].state == event.data["new_state"].state
+        ):
+            return
+
+        music_player_entity_id = self.config_entry.runtime_data.core.musicplayer_device
+        mic_integration = get_config_entry_by_entity_id(
+            self.hass, self.config_entry.runtime_data.core.mic_device
+        ).domain
+        music_player_integration = get_config_entry_by_entity_id(
+            self.hass, music_player_entity_id
+        ).domain
+
+        _LOGGER.debug(
+            "Mic state change: %s: %s->%s",
+            mic_integration,
+            event.data["old_state"].state,
+            event.data["new_state"].state,
+        )
+
+        if mic_integration == "esphome" and music_player_integration == "esphome":
+            # HA VPE already supports volume ducking
+            return
+
+        if (
+            self.hass.states.get(music_player_entity_id).state
+            != MediaPlayerState.PLAYING
+        ):
+            return
+
+        old_state = event.data["old_state"].state
+        new_state = event.data["new_state"].state
+        ducking_volume = self.config_entry.runtime_data.default.ducking_volume / 100
+
+        if (mic_integration == HASSMIC_DOMAIN and old_state == "wake_word-start") or (
+            mic_integration != HASSMIC_DOMAIN
+            and new_state == AssistSatelliteState.LISTENING
+        ):
+            if music_player_volume := self.hass.states.get(
+                music_player_entity_id
+            ).attributes.get("volume_level"):
+                self.music_player_volume = music_player_volume
+
+                if self.hass.states.get(music_player_entity_id):
+                    if music_player_volume > ducking_volume:
+                        _LOGGER.debug("Ducking music player volume: %s", ducking_volume)
+                        await self.hass.services.async_call(
+                            "media_player",
+                            "volume_set",
+                            {
+                                "entity_id": music_player_entity_id,
+                                "volume_level": ducking_volume,
+                            },
+                        )
+        elif (
+            (mic_integration == HASSMIC_DOMAIN and new_state == "wake_word-start")
+            or (
+                mic_integration != HASSMIC_DOMAIN
+                and new_state == AssistSatelliteState.IDLE
+            )
+        ) and self.music_player_volume is not None:
+            if self.hass.states.get(music_player_entity_id):
+                await asyncio.sleep(2)
+                _LOGGER.debug(
+                    "Restoring music player volume: %s", self.music_player_volume
+                )
+                # Restore gradually to avoid sudden volume change
+                for i in range(1, 11):
+                    volume = min(self.music_player_volume, ducking_volume + (i * 0.1))
+                    await self.hass.services.async_call(
+                        "media_player",
+                        "volume_set",
+                        {
+                            "entity_id": music_player_entity_id,
+                            "volume_level": volume,
+                        },
+                        blocking=True,
+                    )
+                    if volume == self.music_player_volume:
+                        break
+                    await asyncio.sleep(0.25)
+                self.music_player_volume = None
 
     @callback
     def _async_on_mic_change(self, event: Event[EventStateChangedData]) -> None:

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -16,6 +16,7 @@ from .const import (
     BROWSERMOD_DOMAIN,
     CONF_DISPLAY_DEVICE,
     DOMAIN,
+    HASSMIC_DOMAIN,
     IMAGE_PATH,
     RANDOM_IMAGE_URL,
     REMOTE_ASSIST_DISPLAY_DOMAIN,
@@ -290,6 +291,24 @@ def get_mute_switch_entity_id(hass: HomeAssistant, mic_entity_id: str) -> str | 
         for entity in device_entities:
             if entity.domain == "switch" and entity.entity_id.endswith(
                 ("_mute", "_mic", "_microphone")
+            ):
+                return entity.entity_id
+    return None
+
+
+def get_hassmic_pipeline_status_entity_id(
+    hass: HomeAssistant, mic_entity_id: str
+) -> str | None:
+    """Get the wakeword entity id for a hassmic device relating to the mic entity."""
+    entity_registry = er.async_get(hass)
+    if mic_entity := entity_registry.async_get(mic_entity_id):
+        if mic_entity.platform != HASSMIC_DOMAIN:
+            return None
+        device_id = mic_entity.device_id
+        device_entities = er.async_entries_for_device(entity_registry, device_id)
+        for entity in device_entities:
+            if entity.domain == "sensor" and entity.entity_id.endswith(
+                "_pipeline_state"
             ):
                 return entity.entity_id
     return None

--- a/custom_components/view_assist/typed.py
+++ b/custom_components/view_assist/typed.py
@@ -126,6 +126,7 @@ class DefaultConfig:
     do_not_disturb: bool | None = None
     use_announce: bool | None = None
     mic_unmute: bool | None = None
+    ducking_volume: int | None = None
 
 
 @dataclass


### PR DESCRIPTION
In this PR - added volume ducking support

- Supports wyoming devices (inc Hassmic 0.9.3), HA VPE  using something else for music player and Hassmic 0.9.1.2
- Reduces volume to that set in default options when pipeline not in idle state (idle state is determined depending on mic integration as not consistent)
- Restores volume gradually after 2 secs of idle

**Tested with**
Hassmic 0.9.3 (Wyoming) & 0.9.1.2 (Hassmic only)
HA VPE using HA VPE as music player (esphome)
HA VPE with snapcast music player (esphome)

**Not tested with**
Stream Assist - issue with dev environment freezing
