### PR TITLE
added: update notifications for views and dashboard

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -1,8 +1,6 @@
 """View Assist custom integration."""
 
-from functools import reduce
 import logging
-from typing import Any
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_TYPE, Platform

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -20,7 +20,6 @@ GITHUB_PATH = "View Assist dashboard and views"
 VIEWS_DIR = "views"
 COMMUNITY_VIEWS_DIR = "community_contributions"
 DASHBOARD_DIR = "dashboard"
-
 DASHBOARD_NAME = "View Assist"
 DEFAULT_VIEW = "clock"
 DEFAULT_VIEWS = [
@@ -58,6 +57,9 @@ JSMODULES = [
         "version": "1.0.10",
     },
 ]
+VERSION_CHECK_INTERVAL = (
+    120  # mins between checks for updated versions of dashboard and views
+)
 
 
 class VAMode(StrEnum):
@@ -113,7 +115,7 @@ CONF_USE_ANNOUNCE = "use_announce"
 CONF_MIC_UNMUTE = "micunmute"
 CONF_DUCKING_VOLUME = "ducking_volume"
 
-
+CONF_ENABLE_UPDATES = "enable_updates"
 CONF_DEVELOPER_DEVICE = "developer_device"
 CONF_DEVELOPER_MIMIC_DEVICE = "developer_mimic_device"
 
@@ -157,6 +159,8 @@ DEFAULT_VALUES = {
     CONF_USE_ANNOUNCE: "off",
     CONF_MIC_UNMUTE: "off",
     CONF_DUCKING_VOLUME: 2,
+    # Default integration options
+    CONF_ENABLE_UPDATES: True,
     # Default developer otions
     CONF_DEVELOPER_DEVICE: "",
     CONF_DEVELOPER_MIMIC_DEVICE: "",
@@ -187,6 +191,7 @@ ATTR_MAX_REPEATS = "max_repeats"
 
 VA_ATTRIBUTE_UPDATE_EVENT = "va_attr_update_event_{}"
 VA_BACKGROUND_UPDATE_EVENT = "va_background_update_{}"
+VA_VIEW_DOWNLOAD_PROGRESS = "va_view_download_progress"
 CC_CONVERSATION_ENDED_EVENT = f"{CUSTOM_CONVERSATION_DOMAIN}_conversation_ended"
 
 

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -385,12 +385,13 @@ def get_key(
 ) -> dict[str, dict | str | int] | str | int:
     """Try to get a deep value from a dict based on a dot-notation."""
 
-    dn_list = dot_notation_path.split(".")
-
     try:
+        if "." in dot_notation_path:
+            dn_list = dot_notation_path.split(".")
+        else:
+            dn_list = [dot_notation_path]
         return reduce(dict.get, dn_list, data)
-    except (TypeError, KeyError) as ex:
-        _LOGGER.error("TYPE ERROR: %s - %s", dn_list, ex)
+    except (TypeError, KeyError):
         return None
 
 

--- a/custom_components/view_assist/translations/en.json
+++ b/custom_components/view_assist/translations/en.json
@@ -45,6 +45,7 @@
         "title": "Configuration",
         "description": "Select which options to amend",
         "menu_options": {
+          "integration_options": "Integration Options",
           "main_config": "Core Device Configuration",
           "dashboard_options": "Dashboard Options",
           "default_options": "Default Options",
@@ -146,6 +147,15 @@
           "do_not_disturb": "Default state for do not disturb mode on HA restart",
           "use_announce": "Some media player devices, like BrowserMod, cannot use the Home Assistant announce feature while media is playing. This option allows for turning off announce messages if problems arise. Default is on.",
           "micunmute": "Helpful for Stream Assist devices"
+        }
+      },
+      "integration_options": {
+        "title": "{name} Integration Options",
+        "data": {
+          "enable_updates": "Enable updates"
+        },
+        "data_description": {
+          "enable_updates": "Enable or disable update notifications for the dashboard and views"
         }
       },
       "developer_options": {

--- a/custom_components/view_assist/typed.py
+++ b/custom_components/view_assist/typed.py
@@ -68,6 +68,13 @@ class VABackgroundMode(StrEnum):
 
 
 @dataclass
+class IntegrationConfig:
+    """Class to hold integration config data."""
+
+    enable_updates: bool = True
+
+
+@dataclass
 class DeviceCoreConfig:
     """Class to hold core config data."""
 
@@ -142,6 +149,7 @@ class MasterConfigRuntimeData:
 
     def __init__(self) -> None:
         """Initialize runtime data."""
+        self.integration: IntegrationConfig = IntegrationConfig()
         self.dashboard: DashboardConfig = DashboardConfig()
         self.default: DefaultConfig = DefaultConfig()
         self.developer_settings: DeveloperConfig = DeveloperConfig()

--- a/custom_components/view_assist/update.py
+++ b/custom_components/view_assist/update.py
@@ -92,6 +92,13 @@ class VAUpdateEntity(UpdateEntity):
         return f"View Assist - {self.view} view"
 
     @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        if self.view == "dashboard":
+            return f"{DOMAIN}_{self.view}"
+        return f"{DOMAIN}_{self.view}_view"
+
+    @property
     def latest_version(self) -> str:
         """Return latest version of the entity."""
         if self.view == "dashboard":

--- a/custom_components/view_assist/update.py
+++ b/custom_components/view_assist/update.py
@@ -1,0 +1,163 @@
+"""Update entities for HACS."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
+from homeassistant.core import HomeAssistant, HomeAssistantError, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    DOMAIN,
+    GITHUB_BRANCH,
+    GITHUB_PATH,
+    GITHUB_REPO,
+    VA_VIEW_DOWNLOAD_PROGRESS,
+    VIEWS_DIR,
+)
+from .dashboard import DASHBOARD_MANAGER, DashboardManager
+from .typed import VAConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: VAConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up update platform."""
+    update_sensors = []
+    dm = hass.data[DOMAIN][DASHBOARD_MANAGER]
+    data = await dm.store.load()
+
+    # Wait upto 5s for view data to be created on first run
+    for _ in range(5):
+        if data.get("views") is not None:
+            break
+        data = await dm.store.load()
+        await asyncio.sleep(1)
+
+    if data.get("views"):
+        update_sensors = [
+            VAUpdateEntity(
+                dm=dm,
+                view=view,
+            )
+            for view in data["views"]
+        ]
+    else:
+        _LOGGER.error("Unable to load view version information")
+
+    if data.get("dashboard"):
+        update_sensors.append(
+            VAUpdateEntity(
+                dm=dm,
+                view="dashboard",
+            )
+        )
+    else:
+        _LOGGER.error("Unable to load dashboard version information")
+
+    async_add_entities(update_sensors)
+
+
+class VAUpdateEntity(UpdateEntity):
+    """Update entities for repositories downloaded with HACS."""
+
+    _attr_supported_features = (
+        UpdateEntityFeature.INSTALL
+        | UpdateEntityFeature.PROGRESS
+        | UpdateEntityFeature.RELEASE_NOTES
+    )
+
+    def __init__(self, dm: DashboardManager, view: str) -> None:
+        """Initialize."""
+        self.dm = dm
+        self.view = view
+
+        self._attr_supported_features = (
+            (self._attr_supported_features | UpdateEntityFeature.BACKUP)
+            if view != "dashboard"
+            else self._attr_supported_features
+        )
+
+    @property
+    def name(self) -> str | None:
+        """Return the name."""
+        if self.view == "dashboard":
+            return f"View Assist - {self.view}"
+        return f"View Assist - {self.view} view"
+
+    @property
+    def latest_version(self) -> str:
+        """Return latest version of the entity."""
+        if self.view == "dashboard":
+            return self.dm.store.data["dashboard"]["latest"]
+        return self.dm.store.data["views"][self.view]["latest"]
+
+    @property
+    def release_url(self) -> str:
+        """Return the URL of the release page."""
+        return f"https://github.com/{GITHUB_REPO}/tree/{GITHUB_BRANCH}/{GITHUB_PATH}/{VIEWS_DIR}/{self.view}"
+
+    @property
+    def installed_version(self) -> str:
+        """Return downloaded version of the entity."""
+        if self.view == "dashboard":
+            return self.dm.store.data["dashboard"]["installed"]
+        return self.dm.store.data["views"][self.view]["installed"]
+
+    @property
+    def release_summary(self) -> str | None:
+        """Return the release summary."""
+        if self.view == "dashboard":
+            return "<ha-alert alert-type='info'>Updating the dashboard will attempt to keep any changes you have made to it</ha-alert>"
+        return "<ha-alert alert-type='warning'>Updating this view will overwrite any changes you have made to it</ha-alert>"
+
+    @property
+    def entity_picture(self) -> str | None:
+        """Return the entity picture to use in the frontend."""
+        return f"https://brands.home-assistant.io/_/{DOMAIN}/icon.png"
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Install an update."""
+        try:
+            if self.view == "dashboard":
+                # Install dashboard
+                await self.dm.update_dashboard(download_from_repo=True)
+            else:
+                # Install view
+                await self.dm.add_update_view(
+                    self.view, download_from_repo=True, backup_current_view=backup
+                )
+        except Exception as exception:
+            raise HomeAssistantError(exception) from exception
+
+    async def async_release_notes(self) -> str | None:
+        """Return the release notes."""
+        # TODO: Get release notes from markdown readme
+        return self.release_summary
+
+    async def async_added_to_hass(self) -> None:
+        """Register for status events."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                VA_VIEW_DOWNLOAD_PROGRESS,
+                self._update_download_progress,
+            )
+        )
+
+    @callback
+    def _update_download_progress(self, data: dict) -> None:
+        """Update the download progress."""
+        if data["view"] != self.view:
+            return
+        self._attr_in_progress = data["progress"]
+        self.async_write_ha_state()


### PR DESCRIPTION
### In this PR:  
## Uses the in-built HA update functionality to notify and allow update of new versions of the dashboard and installed views.

### Enabling/Disabling
- A new configuration menu in master config configuration of integration has been created
- An option under this allows for enbaling/disabling this functionality - default enabled.

### How it works
- A file is created in the .storage folder (view_assist.dashboard) that holds the installed version and latest version.
- The installed version is derived from the version key in the view variables currently in use in the dashboard
- The latest version is derived from reading this same version variable key from the version of the view on the main branch of the github repo.
- This file is updated every 2 hours as defined by the VERSION_CHECK_INTERVAL constant
- The integration uses the HACS github api key to get over the 60 queries per hour github api limit
- For each view and the dashboard, an update entity is created that holds this installed and latest version info.  This update entity checks every 15 mins for changes to the versions in the file in .storage.  Therefore, it will notify of a new version anywhere between 1s and 2h15m (2 hour repo query interval plus 15 min entity update interval) after the new version is published to the repo
- As per standard HA functionality, when an update is notified, this appears as an item in the settings menu.
- From this item, the dashboard and view can be updated
- For views, the option to backup existing is also available.  Backups are created in the view_assist/view/[view_name] folder as [view_name].saved.yaml in the same way as usign the load view service and selecting back option.

### Outstanding actions needed
- The dashboard needs a 'dashboardversion' variable adding
- All views need to have their version variable set consitently to [view_name]version or [view_name]cardversion
- Decision needs to be made if we want to add an update summary to be displayed as part of the update item.

### Known issues
- When adding a new view that has not been installed previsously, the master config needs to be reloaded to start monitoring for updates to that view.  This happens either when the master ocnfig is changed, HA is restarted or reload is selected on the master config.
- Doesn't yet support community contributions
- Doesn't yet allow for updates from a branch other than main, ie dev branch
- Could be more efficient with its querying of the github repo if it looked at last commit before reading all view yaml files

### Images
![image](https://github.com/user-attachments/assets/e073b7f1-0529-423c-95ed-e7710342cde0)

![image](https://github.com/user-attachments/assets/a6a47c9b-82e2-4eb5-aafa-372547a7cc61)

### Testing notes

- You can amend the view_assist.dashboard file in config/.storage to set a lower installed version of a view.
- Restart HA/reload the master config instance and you should see an update notification which can be processed or skipped

- To test the dashboard update, we first need to add a version key to its yaml file.  It should then automatically appear after a while as an update.

