### PR TITLE
Added: service to force version updates

### DIFF
--- a/custom_components/view_assist/dashboard.py
+++ b/custom_components/view_assist/dashboard.py
@@ -357,11 +357,11 @@ class DashboardManager:
 
         # Experimental - schedule update of dashboard view versions
         if self.config.runtime_data.integration.enable_updates:
-            async_at_started(hass, self._update_dashboard_view_versions)
+            async_at_started(hass, self.update_dashboard_view_versions)
             config.async_on_unload(
                 async_track_time_interval(
                     hass,
-                    self._update_dashboard_view_versions,
+                    self.update_dashboard_view_versions,
                     timedelta(minutes=VERSION_CHECK_INTERVAL),
                 )
             )
@@ -674,7 +674,7 @@ class DashboardManager:
                     output[view_name] = self.get_view_version(view_name, view)
         return output
 
-    async def _update_dashboard_view_versions(
+    async def update_dashboard_view_versions(
         self, now: Event | None = None, force: bool = False
     ):
         """Update the version of the views in the dashboard."""
@@ -706,6 +706,14 @@ class DashboardManager:
                 "latest": latest_version,
             }
         await self.store.update_views(view_info)
+
+        if force:
+            # Fire refresh event
+            async_dispatcher_send(
+                self.hass,
+                VA_VIEW_DOWNLOAD_PROGRESS,
+                {"view": "all"},
+            )
 
     async def view_exists(self, view: str) -> int:
         """Return index of view if view exists."""

--- a/custom_components/view_assist/services.py
+++ b/custom_components/view_assist/services.py
@@ -227,6 +227,10 @@ class VAServices:
             schema=DASHVIEW_SERVICE_SCHEMA,
         )
 
+        self.hass.services.async_register(
+            DOMAIN, "update_versions", self.async_handle_update_versions
+        )
+
     # -----------------------------------------------------------------------
     # Get Target Satellite
     # Used to determine which VA satellite is being used based on its microphone device
@@ -421,5 +425,13 @@ class VAServices:
         dm: DashboardManager = self.hass.data[DOMAIN][DASHBOARD_MANAGER]
         try:
             await dm.save_view(view_name)
+        except (DownloadManagerException, DashboardManagerException) as ex:
+            raise HomeAssistantError(ex) from ex
+
+    async def async_handle_update_versions(self, call: ServiceCall):
+        """Handle update of the view versions."""
+        dm: DashboardManager = self.hass.data[DOMAIN][DASHBOARD_MANAGER]
+        try:
+            await dm.update_dashboard_view_versions(force=True)
         except (DownloadManagerException, DashboardManagerException) as ex:
             raise HomeAssistantError(ex) from ex

--- a/custom_components/view_assist/services.yaml
+++ b/custom_components/view_assist/services.yaml
@@ -249,3 +249,6 @@ save_view:
       required: true
       selector:
         text:
+update_versions:
+  name: "Update version info"
+  description: "Get the latest version info of the dashboard and views from the github repo"

--- a/custom_components/view_assist/update.py
+++ b/custom_components/view_assist/update.py
@@ -164,7 +164,8 @@ class VAUpdateEntity(UpdateEntity):
     @callback
     def _update_download_progress(self, data: dict) -> None:
         """Update the download progress."""
-        if data["view"] != self.view:
-            return
-        self._attr_in_progress = data["progress"]
-        self.async_write_ha_state()
+        if data["view"] == self.view:
+            self._attr_in_progress = data["progress"]
+            self.async_write_ha_state()
+        elif data["view"] == "all":
+            self.schedule_update_ha_state(force_refresh=True)


### PR DESCRIPTION
In this PR

### Adds a service to be able to call the version update service manually.

**Service name:** ```view_assist.update_versions```
**Parameters:** ```None```

#### Service purpose
- To help with testing by allowing a change of the version of a view from within the UI editor and then running this service to see the update item raise or pushing an update to the repo and forcing this to read latestest versions.
- Help shorten timeline to get an updated version to someone to fix a bug

Note: It is not needed in normal course as the update is on a scheduled 2 hour interval