### PR TITLE
Refactor Menu and Status Icon Management for Better Separation of Concerns and Consistent Ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome
 
-Welcome to the long awaited, much anticipated View Assist integration beta!  Some of the notable improvements include:
+Welcome to the long awaited, much anticipated View Assist integration!  Some of the notable improvements include:
 
 * All configuration done within the integration.  The days of editing YAML files are over!
 * The View Assist dashboard is now autocreated when a View Assist device with visual output is configured.  This includes assets like default images and soundfiles to be downloaded and preconfigured for use
@@ -15,16 +15,7 @@ Welcome to the long awaited, much anticipated View Assist integration beta!  Som
 
 A HUGE thank you goes out to Mark Parker @msp1974 for his MASSIVE help with making this a reality.  Mark has written the majority of the integration with my guidance.  You should check out his [Home Assistant Integration Examples](https://github.com/msp1974/HAIntegrationExamples) Github if you are intestered in creating your own integration.  His work has propelled View Assist to first class in very short order.  We would not be where we are today without his continued efforts and the hours and hours he has put in to make View Assist better!  Thanks again Mark!
 
-
-
 # Install
-
-## Notes for existing VA users
-
-**A BIG warning for folks who will be updating.  This is a major rewrite so you will be starting from scratch for the most part.  You will definitely want to do a backup of your current VA settings and views and possibly save a copy of your current dashboard to avoid from losing something you would like to keep!**
-
-You will want to delete your View Assist dashboard before installing.  I suggest that you save your dashboard as a text file (Raw configuration copy/paste).  You will need to UPDATE your View Assist blueprints using the new blueprints.  This is done by importing the new version of the blueprint and choosing to update the existing.  This SHOULD allow for you to keep all settings but be warned that this is beta so problems may exist with keeping these settings in some cases.
-
 
 ## HACS
 * Install HACS if you have not already
@@ -44,4 +35,4 @@ Questions, problems, concerns?  Reach out to us on Discord or use the 'Issues' a
 
 # Help
 
-Need help?  Hop on our Discord channel and we'll give you a boost!
+Need help?  Check our [View Assist Wiki](https://dinki.github.io/View-Assist/) for the most up-to-date documentation.  You can also hop on our [View Assist Discord Server](https://discord.gg/3WXXfGAf8T) and we'll give you a boost!

--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -42,7 +42,6 @@ from .const import (
 from .helpers import (
     async_get_download_image,
     async_get_filesystem_images,
-    ensure_menu_button_at_end,
     get_config_entry_by_entity_id,
     get_device_name_from_id,
     get_display_type_from_browser_id,
@@ -566,6 +565,7 @@ class EntityListeners:
 
     @callback
     def _async_on_mic_change(self, event: Event[EventStateChangedData]) -> None:
+        """Handle microphone mute state changes via menu manager."""
         mic_mute_new_state = event.data["new_state"].state
 
         # If not change to mic mute state, exit function
@@ -576,23 +576,30 @@ class EntityListeners:
             return
 
         _LOGGER.debug("MIC MUTE: %s", mic_mute_new_state)
-        d = self.config_entry.runtime_data.dashboard.display_settings
-        status_icons = d.status_icons.copy()
 
-        if mic_mute_new_state == "on" and "mic" not in status_icons:
-            status_icons.append("mic")
-        elif mic_mute_new_state == "off" and "mic" in status_icons:
-            status_icons.remove("mic")
+        # Get entity ID for this config entry
+        entity_id = get_sensor_entity_from_instance(
+            self.hass, self.config_entry.entry_id
+        )
 
-        ensure_menu_button_at_end(status_icons)
+        # Get menu manager to update system icons
+        menu_manager = self.hass.data[DOMAIN]["menu_manager"]
 
-        d.status_icons = status_icons
-        self.update_entity()
+        # Use menu manager to update system icons
+        if mic_mute_new_state == "on":
+            self.hass.async_create_task(
+                menu_manager.update_system_icons(entity_id, add_icons=["mic"])
+            )
+        else:
+            self.hass.async_create_task(
+                menu_manager.update_system_icons(entity_id, remove_icons=["mic"])
+            )
 
     @callback
     def _async_on_mediaplayer_device_mute_change(
         self, event: Event[EventStateChangedData]
     ) -> None:
+        """Handle media player mute state changes via menu manager."""
         mp_mute_new_state = event.data["new_state"].attributes.get(
             "is_volume_muted", False
         )
@@ -606,18 +613,24 @@ class EntityListeners:
             return
 
         _LOGGER.debug("MP MUTE: %s", mp_mute_new_state)
-        d = self.config_entry.runtime_data.dashboard.display_settings
-        status_icons = d.status_icons.copy() if d.status_icons else []
+        
+        # Get entity ID for this config entry
+        entity_id = get_sensor_entity_from_instance(
+            self.hass, self.config_entry.entry_id
+        )
 
-        if mp_mute_new_state and "mediaplayer" not in status_icons:
-            status_icons.append("mediaplayer")
-        elif not mp_mute_new_state and "mediaplayer" in status_icons:
-            status_icons.remove("mediaplayer")
-
-        ensure_menu_button_at_end(status_icons)
-
-        d.status_icons = status_icons
-        self.update_entity()
+        # Get menu manager to update system icons
+        menu_manager = self.hass.data[DOMAIN]["menu_manager"]
+        
+        # Use menu manager to update system icons
+        if mp_mute_new_state:
+            self.hass.async_create_task(
+                menu_manager.update_system_icons(entity_id, add_icons=["mediaplayer"])
+            )
+        else:
+            self.hass.async_create_task(
+                menu_manager.update_system_icons(entity_id, remove_icons=["mediaplayer"])
+            )
 
     async def _async_cc_on_conversation_ended_handler(self, event: Event):
         """Handle custom conversation integration conversation ended event."""
@@ -779,65 +792,51 @@ class EntityListeners:
             await self._async_on_mode_state_change(event)
 
     async def _async_on_dnd_device_state_change(self, event: Event) -> None:
-        """Set dnd status icon."""
-
+        """Handle DND state changes via menu manager."""
         # This is called from our set_service event listener and therefore event data is
         # slightly different.  See set_state_changed_attribute above
         dnd_new_state = event.data["new_value"]
-        d = self.config_entry.runtime_data.dashboard.display_settings
 
         _LOGGER.debug("DND STATE: %s", dnd_new_state)
-        status_icons = d.status_icons.copy()
-        if dnd_new_state and "dnd" not in status_icons:
-            status_icons.append("dnd")
-        elif not dnd_new_state and "dnd" in status_icons:
-            status_icons.remove("dnd")
 
-        ensure_menu_button_at_end(status_icons)
-
-        d.status_icons = status_icons
-        self.update_entity()
-
-    async def _async_on_mode_state_change(self, event: Event) -> None:
-        """Set mode status icon."""
-
-        new_mode = event.data["new_value"]
-        r = self.config_entry.runtime_data
-        d = r.dashboard.display_settings
-
-        _LOGGER.debug("MODE STATE: %s", new_mode)
-
-        # Get current status icons directly from entity state
+        # Get entity ID for this config entry
         entity_id = get_sensor_entity_from_instance(
             self.hass, self.config_entry.entry_id
         )
-        if entity := self.hass.states.get(entity_id):
-            status_icons = list(entity.attributes.get("status_icons", []))
+
+        # Get menu manager to update system icons
+        menu_manager = self.hass.data[DOMAIN]["menu_manager"]
+
+        # Use menu manager to update system icons
+        if dnd_new_state:
+            await menu_manager.update_system_icons(entity_id, add_icons=["dnd"])
         else:
-            status_icons = d.status_icons.copy()
+            await menu_manager.update_system_icons(entity_id, remove_icons=["dnd"])
 
-        modes = [VAMode.HOLD, VAMode.CYCLE]
+    async def _async_on_mode_state_change(self, event: Event) -> None:
+        """Handle mode state changes via menu manager."""
+        new_mode = event.data["new_value"]
+        r = self.config_entry.runtime_data
 
-        # Remove all mode icons
-        for mode in modes:
-            if mode in status_icons:
-                status_icons.remove(mode)
+        _LOGGER.debug("MODE STATE: %s", new_mode)
 
-        # Now add back any you want
-        if new_mode in modes and new_mode not in status_icons:
-            status_icons.append(new_mode)
-
-        ensure_menu_button_at_end(status_icons)
-
-        # Store the updated status icons in the display settings
-        d.status_icons = status_icons
-
-        # Update entity state
-        await self.hass.services.async_call(
-            DOMAIN,
-            "set_state",
-            service_data={"entity_id": entity_id, "status_icons": status_icons},
+        # Get entity ID for this config entry
+        entity_id = get_sensor_entity_from_instance(
+            self.hass, self.config_entry.entry_id
         )
+
+        # Get menu manager to update system icons
+        menu_manager = self.hass.data[DOMAIN]["menu_manager"]
+
+        # Define mode icons that should be shown
+        mode_icons = [VAMode.HOLD, VAMode.CYCLE]
+
+        # Remove all mode icons first
+        await menu_manager.update_system_icons(entity_id, remove_icons=mode_icons)
+
+        # Add current mode icon if it should be shown
+        if new_mode in mode_icons:
+            await menu_manager.update_system_icons(entity_id, add_icons=[new_mode])
 
         self.update_entity()
 

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -102,13 +102,6 @@ def ensure_list(value: str | list[str]):
     return []
 
 
-def ensure_menu_button_at_end(status_icons: list[str]) -> None:
-    """Ensure menu button is always the rightmost (last) status icon."""
-    if "menu" in status_icons:
-        status_icons.remove("menu")
-        status_icons.append("menu")
-
-
 def normalize_status_items(raw_input: Any) -> str | list[str] | None:
     """Normalize and validate status item input.
 
@@ -153,57 +146,6 @@ def normalize_status_items(raw_input: Any) -> str | list[str] | None:
             return str(raw_input["value"])
 
     return None
-
-
-def arrange_status_icons(
-    menu_items: list[str], system_icons: list[str], show_menu_button: bool = False
-) -> list[str]:
-    """Arrange status icons in the correct order."""
-    result = [item for item in menu_items if item != "menu"]
-
-    for icon in system_icons:
-        if icon != "menu" and icon not in result:
-            result.append(icon)
-
-    if show_menu_button:
-        ensure_menu_button_at_end(result)
-
-    return result
-
-
-def update_status_icons(
-    current_icons: list[str],
-    add_icons: list[str] = None,
-    remove_icons: list[str] = None,
-    menu_items: list[str] = None,
-    show_menu_button: bool = False,
-) -> list[str]:
-    """Update a status icons list by adding and/or removing icons."""
-    result = current_icons.copy()
-
-    if remove_icons:
-        for icon in remove_icons:
-            if icon == "menu" and show_menu_button:
-                continue
-            if icon in result:
-                result.remove(icon)
-
-    if add_icons:
-        for icon in add_icons:
-            if icon not in result:
-                if icon != "menu":
-                    result.append(icon)
-
-    if menu_items is not None:
-        system_icons = [
-            icon for icon in result if icon not in menu_items and icon != "menu"
-        ]
-        menu_icon_list = [icon for icon in result if icon in menu_items]
-        result = arrange_status_icons(menu_icon_list, system_icons, show_menu_button)
-    elif show_menu_button:
-        ensure_menu_button_at_end(result)
-
-    return result
 
 
 def get_entity_attribute(hass: HomeAssistant, entity_id: str, attribute: str) -> Any:

--- a/custom_components/view_assist/manifest.json
+++ b/custom_components/view_assist/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/dinki/view_assist_integration/issues",
   "requirements": ["wordtodigits==1.0.2"],
-  "version": "2025.4.2"
+  "version": "2025.5.1"
 }

--- a/custom_components/view_assist/services.py
+++ b/custom_components/view_assist/services.py
@@ -26,6 +26,7 @@ from .const import (
     ATTR_RESUME_MEDIA,
     DOMAIN,
 )
+from .helpers import normalize_status_items
 from .typed import VAConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -197,7 +198,7 @@ class VAServices:
         menu = call.data.get("menu", False)
         timeout = call.data.get("timeout")
 
-        status_items = self._process_status_item_input(raw_status_item)
+        status_items = normalize_status_items(raw_status_item)
         if not status_items:
             _LOGGER.error("Invalid or empty status_item provided")
             return
@@ -215,16 +216,10 @@ class VAServices:
         raw_status_item = call.data.get("status_item")
         menu = call.data.get("menu", False)
 
-        status_items = self._process_status_item_input(raw_status_item)
+        status_items = normalize_status_items(raw_status_item)
         if not status_items:
             _LOGGER.error("Invalid or empty status_item provided")
             return
 
         menu_manager = self.hass.data[DOMAIN]["menu_manager"]
         await menu_manager.remove_status_item(entity_id, status_items, menu)
-
-    def _process_status_item_input(self, raw_input: Any) -> str | list[str] | None:
-        """Process and validate status item input."""
-        from .helpers import normalize_status_items
-
-        return normalize_status_items(raw_input)


### PR DESCRIPTION
## Overview
This PR refactors the menu and status icon management system to provide better separation between system managed icons (mic mute, media player mute, DND, mode indicators) and user managed launch icons. The changes centralize icon management in the MenuManager class and make menu item modifications runtime only to prevent config pollution.

## Key Changes:
- **Centralized Icon Management**: All status icon updates now go through MenuManager
- **Icon Type Separation**: System icons (mic, mediaplayer, dnd, hold, cycle) are now separate from launch icons
- **Runtime Menu Items**: Menu item additions/removals via services are now runtime only and don't persist to config
- **Cleaner Architecture**: Entity listeners now delegate icon management to MenuManager instead of direct manipulation

## Benefits:
- Consistent icon ordering and behavior (menu > system > launch > menu toggle button)
- Prevents config entry pollution from temporary menu items
- Better separation of concerns between system state and user actions
- Easier to maintain and debug icon related issues