### PR TITLE
Dashboard recreation fix & VACA support

### DIFF
--- a/custom_components/view_assist/assets/__init__.py
+++ b/custom_components/view_assist/assets/__init__.py
@@ -139,54 +139,62 @@ class AssetsManager:
         self.store = AssetsManagerStorage(hass)
         self.managers: dict[str, BaseAssetManager] = {}
         self.data: dict[str, Any] = {}
+        self.force_onboard: bool = False
 
     async def async_setup(self) -> None:
         """Set up the AssetManager."""
-        self.data = await self.store.load()
+        try:
+            _LOGGER.debug("Setting up AssetsManager")
+            self.data = await self.store.load()
 
-        # Setup managers
-        for asset_class, manager in ASSET_CLASS_MANAGERS.items():
-            self.managers[asset_class] = manager(
-                self.hass, self.config, self.data.get(asset_class)
-            )
-
-        # Onboard managers
-        await self.onboard_managers()
-
-        # Setup managers
-        for manager in self.managers.values():
-            await manager.async_setup()
-
-        # Add update action
-        self.hass.services.async_register(
-            DOMAIN, "update_versions", self._async_handle_update_versions_service_call
-        )
-
-        # Add load asset action
-        self.hass.services.async_register(
-            DOMAIN,
-            "load_asset",
-            self._async_handle_load_asset_service_call,
-            schema=LOAD_ASSET_SERVICE_SCHEMA,
-        )
-
-        # Add save asset action
-        self.hass.services.async_register(
-            DOMAIN,
-            "save_asset",
-            self._async_handle_save_asset_service_call,
-            schema=SAVE_ASSET_SERVICE_SCHEMA,
-        )
-
-        # Experimental - schedule update of asset latest versions
-        if self.config.runtime_data.integration.enable_updates:
-            self.config.async_on_unload(
-                async_track_time_interval(
-                    self.hass,
-                    self.async_update_version_info,
-                    timedelta(minutes=VERSION_CHECK_INTERVAL),
+            # Setup managers
+            for asset_class, manager in ASSET_CLASS_MANAGERS.items():
+                self.managers[asset_class] = manager(
+                    self.hass, self.config, self.data.get(asset_class)
                 )
+
+            # Onboard managers
+            await self.onboard_managers()
+
+            # Setup managers
+            for manager in self.managers.values():
+                await manager.async_setup()
+
+            # Add update action
+            self.hass.services.async_register(
+                DOMAIN,
+                "update_versions",
+                self._async_handle_update_versions_service_call,
             )
+
+            # Add load asset action
+            self.hass.services.async_register(
+                DOMAIN,
+                "load_asset",
+                self._async_handle_load_asset_service_call,
+                schema=LOAD_ASSET_SERVICE_SCHEMA,
+            )
+
+            # Add save asset action
+            self.hass.services.async_register(
+                DOMAIN,
+                "save_asset",
+                self._async_handle_save_asset_service_call,
+                schema=SAVE_ASSET_SERVICE_SCHEMA,
+            )
+
+            # Experimental - schedule update of asset latest versions
+            if self.config.runtime_data.integration.enable_updates:
+                self.config.async_on_unload(
+                    async_track_time_interval(
+                        self.hass,
+                        self.async_update_version_info,
+                        timedelta(minutes=VERSION_CHECK_INTERVAL),
+                    )
+                )
+        except Exception as ex:
+            _LOGGER.error("Error setting up AssetsManager. Error is %s", ex)
+            raise HomeAssistantError(f"Error setting up AssetsManager: {ex}") from ex
 
     async def _async_handle_update_versions_service_call(self, call: ServiceCall):
         """Handle update of the view versions."""
@@ -224,11 +232,17 @@ class AssetsManager:
 
     async def onboard_managers(self) -> None:
         """Onboard the user if not yet setup."""
+        # Check dashboard has not been deleted.
+        # Ensures re-onboarded if it has
+        if not self.managers[AssetClass.DASHBOARD].is_installed("dashboard"):
+            _LOGGER.debug("Dashboard not installed, forcing onboarding")
+            self.force_onboard = True
+
         # Check if onboarding is needed and if so, run it
         for asset_class, manager in self.managers.items():
-            if not self.data.get(asset_class):
+            if not self.data.get(asset_class) or self.force_onboard:
                 _LOGGER.debug("Onboarding %s", asset_class)
-                result = await manager.async_onboard()
+                result = await manager.async_onboard(force=self.force_onboard)
 
                 if result:
                     _LOGGER.debug("Onboarding result %s - %s", asset_class, result)
@@ -253,6 +267,14 @@ class AssetsManager:
             managers = {k: v for k, v in self.managers.items() if k == asset_class}
 
         for asset_class, manager in managers.items():  # noqa: PLR1704
+            # If no key in self.data, return
+            if not self.data.get(asset_class):
+                _LOGGER.debug(
+                    "No data for %s, skipping update",
+                    asset_class,
+                )
+                continue
+
             # Reduces download by only getting version from repo if the last commit date is greater than
             # we have stored
             update_from_repo = True

--- a/custom_components/view_assist/assets/base.py
+++ b/custom_components/view_assist/assets/base.py
@@ -40,7 +40,7 @@ class BaseAssetManager:
     async def async_setup(self) -> None:
         """Set up the AssetManager."""
 
-    async def async_onboard(self) -> dict[str, Any]:
+    async def async_onboard(self, force: bool = False) -> dict[str, Any]:
         """Onboard the asset manager."""
         return {}
 

--- a/custom_components/view_assist/assets/blueprints.py
+++ b/custom_components/view_assist/assets/blueprints.py
@@ -36,10 +36,10 @@ BLUEPRINT_MANAGER = "blueprint_manager"
 class BlueprintManager(BaseAssetManager):
     """Manage blueprints for View Assist."""
 
-    async def async_onboard(self) -> None:
+    async def async_onboard(self, force: bool = False) -> None:
         """Load blueprints for initialisation."""
         # Check if onboarding is needed and if so, run it
-        if not self.data:
+        if not self.data or force:
             # Load all blueprints
             self.onboarding = True
             bp_versions = {}

--- a/custom_components/view_assist/assets/dashboard.py
+++ b/custom_components/view_assist/assets/dashboard.py
@@ -53,7 +53,7 @@ class DashboardManager(BaseAssetManager):
             self.hass.bus.async_listen(EVENT_LOVELACE_UPDATED, self._dashboard_changed)
         )
 
-    async def async_onboard(self) -> dict[str, Any] | None:
+    async def async_onboard(self, force: bool = False) -> dict[str, Any] | None:
         """Onboard the user if not yet setup."""
         name = "dashboard"
         db_version = {}

--- a/custom_components/view_assist/assets/views.py
+++ b/custom_components/view_assist/assets/views.py
@@ -25,10 +25,10 @@ _LOGGER = logging.getLogger(__name__)
 class ViewManager(BaseAssetManager):
     """Class to manage view assets."""
 
-    async def async_onboard(self) -> dict[str, Any] | None:
+    async def async_onboard(self, force: bool = False) -> dict[str, Any] | None:
         """Onboard the user if not yet setup."""
         # Check if onboarding is needed and if so, run it
-        if not self.data:
+        if not self.data or force:
             self.onboarding = True
             vw_versions = {}
             views = await self._async_get_view_list()

--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -68,6 +68,7 @@ from .const import (
     DEFAULT_VALUES,
     DOMAIN,
     REMOTE_ASSIST_DISPLAY_DOMAIN,
+    VACA_DOMAIN,
     VAAssistPrompt,
     VAIconSizes,
 )
@@ -108,7 +109,7 @@ BASE_DEVICE_SCHEMA = vol.Schema(
                         integration="wyoming", domain=ASSIST_SAT_DOMAIN
                     ),
                     EntityFilterSelectorConfig(
-                        integration="va_wyoming", domain=ASSIST_SAT_DOMAIN
+                        integration=VACA_DOMAIN, domain=ASSIST_SAT_DOMAIN
                     ),
                 ]
             )

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -31,6 +31,7 @@ BROWSERMOD_DOMAIN = "browser_mod"
 REMOTE_ASSIST_DISPLAY_DOMAIN = "remote_assist_display"
 CUSTOM_CONVERSATION_DOMAIN = "custom_conversation"
 HASSMIC_DOMAIN = "hassmic"
+VACA_DOMAIN = "vaca"
 USE_VA_NAVIGATION_FOR_BROWSERMOD = True
 
 IMAGE_PATH = "images"
@@ -42,7 +43,7 @@ JSMODULES = [
     {
         "name": "View Assist Helper",
         "filename": "view_assist.js",
-        "version": "1.0.12",
+        "version": "1.0.13",
     },
 ]
 VERSION_CHECK_INTERVAL = (

--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -467,6 +467,7 @@ class EntityListeners:
         # If not change to mic state, exit function
         if (
             not event.data.get("old_state")
+            or not event.data.get("new_state")
             or event.data["old_state"].state == event.data["new_state"].state
         ):
             return
@@ -609,6 +610,9 @@ class EntityListeners:
     def _async_on_mediaplayer_device_mute_change(
         self, event: Event[EventStateChangedData]
     ) -> None:
+        if not event.data.get("new_state"):
+            return
+
         mp_mute_new_state = event.data["new_state"].attributes.get(
             "is_volume_muted", False
         )

--- a/custom_components/view_assist/update.py
+++ b/custom_components/view_assist/update.py
@@ -89,7 +89,7 @@ async def async_setup_entry(
                 {
                     "asset_class": asset_class,
                     "name": name,
-                    "remove": AwesomeVersion(installed) >= latest,
+                    "remove": not installed or AwesomeVersion(installed) >= latest,
                 },
                 startup=True,
             )


### PR DESCRIPTION
## In this PR

1. Fix for dashboard not being recreated if removed.  Deleting file config/.storage/view_assist.assets is a workaround.
2. Support for VACA
3. Handle error when mic device removed