### PR TITLE
Fix intra group icon ordering - new icons appear left instead of right

### DIFF
--- a/custom_components/view_assist/menu_manager.py
+++ b/custom_components/view_assist/menu_manager.py
@@ -425,7 +425,7 @@ class MenuManager:
             changed = False
             for item in items:
                 if item not in menu_state.launch_icons:
-                    menu_state.launch_icons.append(item)
+                    menu_state.launch_icons.insert(0, item)
                     changed = True
 
             if changed:

--- a/custom_components/view_assist/menu_manager.py
+++ b/custom_components/view_assist/menu_manager.py
@@ -351,7 +351,7 @@ class MenuManager:
         if add_icons:
             for icon in add_icons:
                 if icon in SYSTEM_ICONS and icon not in menu_state.system_icons:
-                    menu_state.system_icons.append(icon)
+                    menu_state.system_icons.insert(0, icon)
 
         # Always rebuild status icons with all icons (frontend handles display)
         updated_icons = self._arrange_status_icons(


### PR DESCRIPTION
Fixes issue where new system and launch icons were being added to the right of existing icons in their group, causing lots of unwanted movement of existing icons. This was also inconsistent with existing menu item behavior.

System and Launch icons are now being properly added to the left of existing icons in their group.

