### PR TITLE
Listening overlays in javascript helper

### DIFF
--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -37,6 +37,7 @@ from .const import (
     USE_VA_NAVIGATION_FOR_BROWSERMOD,
     VA_ATTRIBUTE_UPDATE_EVENT,
     VA_BACKGROUND_UPDATE_EVENT,
+    VACA_DOMAIN,
     VAMode,
 )
 from .helpers import (
@@ -490,10 +491,30 @@ class EntityListeners:
             event.data["new_state"].state,
         )
 
+        # Send event to display new javascript overlays
+        # Convert state to standard for stt and hassmic
+        state = event.data["new_state"].state
+        if state in ["vad", "sst-listening"]:
+            state = AssistSatelliteState.LISTENING
+        elif state in ["start", "intent-processing"]:
+            state = AssistSatelliteState.PROCESSING
+
+        async_dispatcher_send(
+            self.hass,
+            f"{DOMAIN}_{self.config_entry.entry_id}_event",
+            VAEvent(
+                "listening",
+                {
+                    "state": state,
+                    "style": self.config_entry.runtime_data.dashboard.display_settings.assist_prompt,
+                },
+            ),
+        )
+
         if mic_integration in (
             "esphome",
-            "va_wyoming",
-        ) and music_player_integration in ("esphome", "va_wyoming"):
+            VACA_DOMAIN,
+        ) and music_player_integration in ("esphome", VACA_DOMAIN):
             # HA VPE already supports volume ducking
             return
 

--- a/custom_components/view_assist/translations/en.json
+++ b/custom_components/view_assist/translations/en.json
@@ -191,7 +191,8 @@
     "assist_prompt_selector": {
       "options": {
         "blur_pop_up": "Blurs the screen and shows pop up",
-        "flashing_bar": "Flashing bar at bottom"
+        "flashing_bar": "Flashing bar at bottom",
+        "kitt_bar": "KITT style bar at bottom"
       }
     },
     "status_icons_size_selector": {

--- a/custom_components/view_assist/typed.py
+++ b/custom_components/view_assist/typed.py
@@ -40,6 +40,7 @@ class VAAssistPrompt(StrEnum):
 
     BLUR_POPUP = "blur_pop_up"
     FLASHING_BAR = "flashing_bar"
+    KITT_BAR = "kitt_bar"
 
 
 class VAIconSizes(StrEnum):


### PR DESCRIPTION
## In this PR

Overlays are now part of the javascript helper functions and can be removed form the dashboard.yaml file.

This supports the listening and processing overlays showing on custom views in the view assist dashboard

### How it works
- When the VAHelper javascript initialises, it:
  - injects a css link into the HASS page pointing to `http://[ha host]/view_assist/dashboard/overlay.css`
  - injects the html found in overlay.html (in the same path as the css file) into the HASS page.
- When the defined microphone sensor shows it is listening or processing the integration sends an event which causes the specified overlay to be made visible and then hide again when completed.

### Dependancies
- This change requires the overlay.css and overlay.html files to be added to the dashboard folder on the View Assist repository (provided seperately).
- This change requires the current dashboard overlays to be removed.  This involves removing the following:
  - the var_assisting variable
  - the var_assisting_text variable
  - the var_assist_prompt variable
  - the asssit_template template
  - removal of the assist_template entry in all views
  - this is all optional clean up and can be left, providing that the var_assisting variable always returns false to disable the functionality.

### Customisation
- Overlays can be customised by amending the html and/or css in these overlay files.
- At present, however, they could be overwritten with a dashboard update!

