### PR TITLE
Intent info fix

### DIFF
--- a/custom_components/view_assist/entity_listeners.py
+++ b/custom_components/view_assist/entity_listeners.py
@@ -637,7 +637,6 @@ class EntityListeners:
     def _async_on_mediaplayer_device_mute_change(
         self, event: Event[EventStateChangedData]
     ) -> None:
-
         """Handle media player mute state changes via menu manager."""
         if not event.data.get("new_state"):
             return
@@ -655,7 +654,7 @@ class EntityListeners:
             return
 
         _LOGGER.debug("MP MUTE: %s", mp_mute_new_state)
-        
+
         # Get entity ID for this config entry
         entity_id = get_sensor_entity_from_instance(
             self.hass, self.config_entry.entry_id
@@ -663,7 +662,7 @@ class EntityListeners:
 
         # Get menu manager to update system icons
         menu_manager = self.hass.data[DOMAIN]["menu_manager"]
-        
+
         # Use menu manager to update system icons
         if mp_mute_new_state:
             self.hass.async_create_task(
@@ -671,7 +670,9 @@ class EntityListeners:
             )
         else:
             self.hass.async_create_task(
-                menu_manager.update_system_icons(entity_id, remove_icons=["mediaplayer"])
+                menu_manager.update_system_icons(
+                    entity_id, remove_icons=["mediaplayer"]
+                )
             )
 
     async def _async_cc_on_conversation_ended_handler(self, event: Event):
@@ -788,7 +789,7 @@ class EntityListeners:
                     self.config_entry.runtime_data.dashboard.list_view
                 )
 
-            else:
+            elif not event.data["new_state"].attributes.get("processed_locally", False):
                 word_count = len(speech_text.split())
                 message_font_size = ["10vw", "8vw", "6vw", "4vw"][
                     min(word_count // 6, 3)


### PR DESCRIPTION
## In this PR

Having created an intent sensor for VACA that updates each time an intent is processed, when configuring this in VA, it shows the info screen with the repsonse text on every command that does not affect an entity or todo list.  Ie 'whats the weather' shows the info screen with the weather response instead of the weather view as per the blueprint.

This minor change checks to see if the intent was processed by HA or not and only displays the info page if not (ie it came from an LLM).  All other displays of changed entities or the todo list continue to work as before.

This now seems to make more sense and works as I think it was intended.