### PR TITLE
fix: master config fallback for empty lists

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -318,7 +318,11 @@ def set_runtime_data_for_config(
         attr: str, is_master: bool = False
     ) -> str | float | list | None:
         value = get_key(attr, dict(config_entry.options))
-        if not is_master and (value is None or (isinstance(value, dict) and not value)):
+        if not is_master and (
+            value is None
+            or (isinstance(value, dict) and not value)
+            or (isinstance(value, list) and not value)
+        ):
             value = get_key(attr, dict(master_config_options))
         if value is None or (isinstance(value, dict) and not value):
             value = get_key(attr, DEFAULT_VALUES)


### PR DESCRIPTION
## Issue

Device configuration keys with empty lists (e.g., status_icons: [], menu_items: []) were not falling back to master configuration values. This broke the intended configuration hierarchy, where device configs should inherit from master config when values are unset.
The issue occurred because the get_config_value function in __init__.py only checked for None values and empty dictionaries when determining whether to fall back to master configuration, but ignored empty lists.

## Solution

Updated the fallback condition in get_config_value to also check for empty lists.