### PR TITLE
fix: use 'menu' parameter in remove_status_item service

### DIFF
--- a/custom_components/view_assist/services.yaml
+++ b/custom_components/view_assist/services.yaml
@@ -344,7 +344,7 @@ remove_status_item:
       required: true
       selector:
         object:
-    from_menu_items:
+    menu:
       name: "Remove from Menu Items"
       description: "If true, removes the item(s) from the configured menu items list. If false, removes from status icons."
       required: false


### PR DESCRIPTION
Updates services.yaml to use 'menu' parameter instead of 'from_menu_items' or remove_status_item service, matching the existing add_status_item service and resolving validation error "extra keys not allowed".