### PR TITLE
added: HAVPE timer support

### DIFF
--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -58,7 +58,7 @@ JSMODULES = [
     {
         "name": "View Assist Helper",
         "filename": "view_assist.js",
-        "version": "1.0.20",
+        "version": "1.0.21",
     },
 ]
 # mins between checks for updated versions of dashboard and views

--- a/custom_components/view_assist/core/websocket.py
+++ b/custom_components/view_assist/core/websocket.py
@@ -205,7 +205,7 @@ class WebsocketListenerHandler:
         if event.event_name == VAEventType.TIMER_UPDATE:
             if timers := TimerManager.get(self.hass):
                 event.payload = timers.get_timers(
-                    device_or_entity_id=self.entity_id, include_expired=True
+                    entity_id=self.entity_id, include_expired=True
                 )
 
         # Add config data to event
@@ -259,7 +259,7 @@ class WebsocketListenerHandler:
             timer_info = {}
             if timers := TimerManager.get(self.hass):
                 timer_info = timers.get_timers(
-                    device_or_entity_id=self.entity_id, include_expired=True
+                    entity_id=self.entity_id, include_expired=True
                 )
 
             menu_info = {}

--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -165,6 +165,31 @@ def get_devices_for_domain(hass: HomeAssistant, domain: str) -> list[dr.DeviceEn
     return []
 
 
+def get_mic_device_domain(hass: HomeAssistant, entity_id: str) -> str | None:
+    """Get the mic device domain of an entity by id."""
+    entity_registry = er.async_get(hass)
+    if va_entity := entity_registry.async_get(entity_id):
+        va_entry = hass.config_entries.async_get_entry(va_entity.config_entry_id)
+        if mic_entity := va_entry.data.get("mic_device"):
+            mic_entity_entry = entity_registry.async_get(mic_entity)
+            if mic_entity_entry:
+                entry_id = mic_entity_entry.config_entry_id
+                entry = hass.config_entries.async_get_entry(entry_id)
+                if entry:
+                    return entry.domain
+    return None
+
+
+def get_mic_device_id_from_entity_id(hass: HomeAssistant, entity_id: str) -> str | None:
+    """Get the mic device id of an entity by id."""
+    entity_registry = er.async_get(hass)
+    if va_entity := entity_registry.async_get(entity_id):
+        va_entry = hass.config_entries.async_get_entry(va_entity.config_entry_id)
+        if mic_entity := va_entry.data.get("mic_device"):
+            return entity_registry.async_get(mic_entity).device_id
+    return None
+
+
 def get_device_id_from_name(hass: HomeAssistant, device_name: str) -> str:
     """Get the device id of the device with the given name."""
 

--- a/custom_components/view_assist/js_modules/timers.js
+++ b/custom_components/view_assist/js_modules/timers.js
@@ -30,7 +30,7 @@ class TimerCards {
 
             let name = timer.name;
             if (!name && timer.timer_type == 'interval') {
-                name = timer.extra_info.sentence
+                name = timer.duration
             }
 
             let expiry_time = timer.expiry.time;
@@ -201,6 +201,11 @@ class TimerCards {
         const timer = window.viewassist.config?.timers.find(t => t.id === timer_id && (t.entity_id === entity_id || !entity_id));
         if (!timer) return card;
 
+        let name = timer.name;
+        if (!name && timer.timer_type == 'interval') {
+            name = timer.duration
+        }
+
 
         function actionButton(action_name, width, background_colour, text_colour, tap_action, display) {
             return {
@@ -283,7 +288,7 @@ class TimerCards {
                 },
             },
             "custom_fields": {
-                "display_timer_name": timer.name,
+                "display_timer_name": name,
                 "time": (timer.timer_type == 'interval') ? `<viewassist-countdown expires='${timer.expires}'></viewassist-countdown>` : timer.expiry.time,
                 "day": (timer.timer_type == 'interval') ? '' : (timer.expiry.day != "Today") ? timer.expiry.day : '',
                 "action_buttons": {

--- a/custom_components/view_assist/js_modules/view_assist.js
+++ b/custom_components/view_assist/js_modules/view_assist.js
@@ -1,6 +1,6 @@
-import { timerCards } from "./timers.js?v=1.0.20";
+import { timerCards } from "./timers.js?v=1.0.21";
 
-const version = "1.0.20"
+const version = "1.0.21"
 const TIMEOUT_ERROR = "SELECTTREE-TIMEOUT";
 
 export async function await_element(el, hard = false) {
@@ -308,12 +308,6 @@ class ViewAssistHelpers {
     if (timerCount == 0) return timerCards.noTimersCard();
 
     if (timerCount > 1) {
-      //const entity_id = localStorage.getItem("view_assist_sensor");
-      //const expired_timers = window.viewassist.config?.timers.filter(t => t.status === 'expired');
-      //console.log("Expired timers: ", expired_timers);
-      //if (expired_timers.length > 0 && !show_all) {
-      //  return timerCards.singleTimerCard(expired_timers[0].id);
-      // }
       return timerCards.timerCards(show_all);
     } else {
       return timerCards.singleTimerCard(window.viewassist.config.timers[0].id);

--- a/custom_components/view_assist/manifest.json
+++ b/custom_components/view_assist/manifest.json
@@ -3,7 +3,7 @@
   "name": "View Assist",
   "codeowners": ["@dinki"],
   "config_flow": true,
-  "dependencies": ["http","lovelace","blueprint", "google_assistant"],
+  "dependencies": ["http","lovelace","blueprint", "google_assistant", "esphome"],
   "documentation": "https://github.com/dinki/view_assist_integration",
   "integration_type": "device",
   "iot_class": "calculated",

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -187,7 +187,7 @@ class ViewAssistSensor(SensorEntity):
         d = self.config.runtime_data.default
 
         tm = TimerManager.get(self.hass)
-        timers = tm.get_timers(device_or_entity_id=self.entity_id)
+        timers = tm.get_timers(entity_id=self.entity_id)
         return {
             "last_updated": dt.now().isoformat(),
             "do_not_disturb": d.do_not_disturb,

--- a/custom_components/view_assist/translations/timers/en.json
+++ b/custom_components/view_assist/translations/timers/en.json
@@ -60,14 +60,12 @@
     "responses": {
         "timer_set": "Timer set for {time}",
         "timer_named_set": "{name} timer set for {time}",
-        "timer_named_snoozed": "{name} timer snoozed for {snooze_duration}",
-        "timer_snoozed": "Timer snoozed for {snooze_duration}",
-        "timer_already_exists": "A timer called {name} already exists",
         "timer_none": "No timers are set",
         "timer_list": "You have the following timers set: {timers}",
         "timer_cancelled": "Cancelled timer {name}",
         "timer_not_found": "No timer called {name} could be found",
         "time_remaining": "{remaining} remaining on timer {name}",
+        "timer_already_exists": "A timer called {name} already exists",
         "timer_error": "Unable to decode time or interval information"
     }
 }


### PR DESCRIPTION
## In this PR

- Added support for using our in-built ehanced timer functions with a HAVPE, supporting the countdown led ring and internal alarm.
- Added HA reboot persistance for HAVPE timers
- Improved finding timers by name, duration etc in get_timers service to better support blueprint commands


