### PR TITLE
added: intent trigger for automations

### DIFF
--- a/custom_components/view_assist/core/__init__.py
+++ b/custom_components/view_assist/core/__init__.py
@@ -19,6 +19,7 @@ from ..helpers import get_integration_entries  # noqa: TID252
 from ..typed import VAConfigEntry  # noqa: TID252
 from .alarm_repeater import AlarmRepeater
 from .http import HTTPManager
+from .intents import IntentsManager
 from .javascript import JSModuleRegistration
 from .services import Services
 from .templates import TemplatesManager
@@ -38,6 +39,7 @@ LOAD_MODULES = [
     TimerManager,
     AlarmRepeater,
     WebsocketManager,
+    IntentsManager,
 ]
 
 

--- a/custom_components/view_assist/core/intents.py
+++ b/custom_components/view_assist/core/intents.py
@@ -1,0 +1,192 @@
+"""Manage VA intents."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from homeassistant.const import CONF_COMMAND
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.intent import (
+    DATA_KEY as INTENT_DATA_KEY,
+    Intent,
+    IntentHandler,
+    IntentResponse,
+    async_register,
+    async_remove,
+)
+
+from ..const import DOMAIN  # noqa: TID252
+from ..helpers import get_entity_id_from_conversation_device_id  # noqa: TID252
+from ..typed import VAConfigEntry  # noqa: TID252
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class IntentTriggerDetails:
+    """List of commands and the callback for a trigger."""
+
+    intent: str
+    command: str | None
+    callback: Callable[..., Awaitable[None]]
+
+
+@dataclass(slots=True)
+class IntentTriggerResponse:
+    """Response from an intent trigger."""
+
+    conversation_response: str | None = None
+    response_slots: dict[str, Any] | None = None
+
+
+class IntentsManager:
+    """Manage VA intents."""
+
+    @classmethod
+    def get(cls, hass: HomeAssistant) -> IntentsManager | None:
+        """Get the intents manager for a config entry."""
+        try:
+            return hass.data[DOMAIN][cls.__name__]
+        except KeyError:
+            return None
+
+    def __init__(self, hass: HomeAssistant, config: VAConfigEntry) -> None:
+        """Initialise."""
+        self.hass = hass
+        self.config = config
+        self.triggers: dict[str, Callable[..., Awaitable[None]]] = {}
+
+    async def async_setup(self) -> bool:
+        """Set up the Intents Manager."""
+        async_register(self.hass, VAIntentHandler())
+        self.register_intent_hooks()
+        return True
+
+    async def async_unload(self) -> bool:
+        """Unload the Intents Manager."""
+        # Currently nothing to unload
+        self.unregister_intent_hooks()
+        async_remove(self.hass, VAIntentHandler.intent_type)
+        return True
+
+    def register_intent_hooks(self):
+        """Get registered intents."""
+        all_intents = self.hass.data.get(INTENT_DATA_KEY, {}).copy()
+        for intent_type, handler in all_intents.items():
+            _LOGGER.debug("Registered intent: %s -> %s", intent_type, handler)
+            async_remove(self.hass, intent_type)
+            async_register(
+                self.hass,
+                IntentHookHandler(
+                    real_handler=handler,
+                ),
+            )
+
+    def unregister_intent_hooks(self):
+        """Unregister intent hooks and restore original handlers."""
+        all_intents = self.hass.data.get(INTENT_DATA_KEY, {}).copy()
+        for intent_type, handler in all_intents.items():
+            if isinstance(handler, IntentHookHandler) and handler.real_handler:
+                _LOGGER.debug("Restoring original intent handler for: %s", intent_type)
+                async_remove(self.hass, intent_type)
+                async_register(self.hass, handler.real_handler)
+
+    def register_trigger(self, trigger: IntentTriggerDetails) -> Callable:
+        """Register a trigger."""
+        trigger_name = (
+            f"{trigger.intent}_{trigger.command}" if trigger.command else trigger.intent
+        )
+        self.triggers[trigger_name] = trigger.callback
+
+        @callback
+        def unregister_trigger() -> None:
+            """Unregister the trigger."""
+            self.triggers.pop(trigger_name, None)
+
+        return unregister_trigger
+
+    async def async_process_triggers(
+        self, intent_obj: Intent
+    ) -> IntentTriggerResponse | None:
+        """Process triggers for a given intent."""
+        trigger_name = (
+            f"{intent_obj.intent_type}_{intent_obj.slots[CONF_COMMAND]['value']}"
+            if intent_obj.slots.get(CONF_COMMAND)
+            else intent_obj.intent_type
+        )
+        _LOGGER.debug("Looking for trigger: %s", trigger_name)
+        if trigger_name in self.triggers:
+            _LOGGER.debug("Processing triggers for intent: %s", trigger_name)
+            extra_data = await self.get_trigger_extra_data(intent_obj)
+            result = await self.triggers[trigger_name](intent_obj, extra_data)
+            _LOGGER.debug("Trigger result: %s", result)
+            return result
+        return None
+
+    async def get_trigger_extra_data(self, intent_obj: Intent) -> dict[str, Any]:
+        """Get extra data for the intent."""
+        display = (
+            get_entity_id_from_conversation_device_id(self.hass, intent_obj.device_id)
+            if intent_obj.device_id
+            else None
+        )
+        return {"display": display}
+
+
+class VAIntentHandler(IntentHandler):
+    """Intent handler for VA intents."""
+
+    intent_type = "VACustomIntent"
+    description = "Handles custom View Assist intents"
+
+    async def async_handle(self, intent_obj: Intent) -> IntentResponse:
+        """Handle the intent."""
+        _LOGGER.debug("VAIntentHandler invoked with intent: %s", intent_obj.slots)
+        response = intent_obj.create_response()
+
+        # TODO: Add custom handling logic here with before/after hooks, pre-defined slots, etc.
+
+        _LOGGER.debug("Handling VACustomIntent intent: %s", response.as_dict())
+        return response
+
+
+class IntentHookHandler(IntentHandler):
+    """Base class for intent handlers with custom hooks."""
+
+    def __init__(
+        self,
+        real_handler: IntentHandler | None = None,
+    ) -> None:
+        """Initialize the intent handler."""
+        self.intent_type = real_handler.intent_type
+        self.platforms = real_handler.platforms
+        self.description = (
+            real_handler.description or f"Hooked handler for {real_handler.intent_type}"
+        )
+        self.real_handler = real_handler
+
+    async def async_handle(self, intent_obj: Intent) -> IntentResponse:
+        """Handle the intent with custom logic."""
+        _LOGGER.debug(
+            "%s invoked with intent: %s -> %s",
+            self.__class__.__name__,
+            intent_obj.intent_type,
+            intent_obj.slots,
+        )
+        # Custom handling logic can be added here
+        if im := IntentsManager.get(intent_obj.hass):
+            result = await im.async_process_triggers(intent_obj)
+
+        # Call original handler
+        response = await self.real_handler.async_handle(intent_obj)
+        if result:
+            if result.conversation_response:
+                response.async_set_speech(result.conversation_response)
+            if result.response_slots:
+                response.async_set_speech_slots(result.response_slots)
+
+        _LOGGER.debug("%s response: %s", self.__class__.__name__, response.as_dict())
+        return response

--- a/custom_components/view_assist/trigger.py
+++ b/custom_components/view_assist/trigger.py
@@ -1,0 +1,153 @@
+"""View Assist trigger dispatcher."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_COMMAND, CONF_OPTIONS
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.intent import Intent
+from homeassistant.helpers.script import UNDEFINED, ScriptRunResult
+from homeassistant.helpers.trigger import Trigger, TriggerActionRunner, TriggerConfig
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+from .core.intents import IntentsManager, IntentTriggerDetails, IntentTriggerResponse
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_INTENT = "intent"
+
+_OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_INTENT): cv.string,
+        vol.Optional(CONF_COMMAND): cv.string,
+    }
+)
+
+_CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS): _OPTIONS_SCHEMA,
+    }
+)
+
+
+class VAIntentTrigger(Trigger):
+    """Trigger on events."""
+
+    _options: dict[str, Any]
+
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        """Validate trigger-specific config."""
+        return _CONFIG_SCHEMA(config)
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize trigger."""
+        super().__init__(hass, config)
+        assert config.options is not None
+        self._options = config.options
+        self._unregister: CALLBACK_TYPE | None = None
+
+    async def async_attach_runner(
+        self, run_action: TriggerActionRunner
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger."""
+
+        @callback
+        def async_remove() -> None:
+            """Remove trigger."""
+            _LOGGER.warning(
+                "Unregistering intent trigger -> %s - %s",
+                self._options[CONF_INTENT],
+                self._options.get(CONF_COMMAND),
+            )
+            if self._unregister:
+                self._unregister()
+
+        async def async_on_event(
+            intent_obj: Intent, extra_data: dict[str, Any] | None = None
+        ) -> IntentTriggerResponse | None:
+            """Handle event."""
+
+            satellite_id = intent_obj.satellite_id
+            device_id = intent_obj.device_id
+
+            trigger_input: dict[str, Any] = {  # Satisfy type checker
+                "platform": DOMAIN,
+                "sentence": intent_obj.text_input,
+                "slots": {  # direct access to values
+                    entity_name: entity["value"]
+                    for entity_name, entity in intent_obj.slots.items()
+                },
+                "device_id": device_id,
+                "satellite_id": satellite_id,
+            }
+
+            if extra_data:
+                trigger_input.update(extra_data)
+
+            _LOGGER.debug("Running automation for intent trigger: %s", trigger_input)
+
+            automation_result = await run_action(
+                trigger_input,
+                f"Intent Trigger for {intent_obj.intent_type}",
+            )
+
+            _LOGGER.debug("Automation result: %s", automation_result)
+            response = IntentTriggerResponse()
+
+            if isinstance(automation_result, ScriptRunResult):
+                if automation_result.conversation_response not in (None, UNDEFINED):
+                    response.conversation_response = (
+                        automation_result.conversation_response
+                    )  # type: ignore[return-value]
+
+                # Add variables as response slots
+                if automation_result.variables not in (None, UNDEFINED):
+                    for key, value in automation_result.variables.items():
+                        if key not in ("this", "trigger", "context"):
+                            if response.response_slots is None:
+                                response.response_slots = {}
+                            response.response_slots[key] = value
+                return response
+
+            # It's important to return None here instead of a string.
+            #
+            # When editing in the UI, a copy of this trigger is registered.
+            # If we return a string from here, there is a race condition between the
+            # two trigger copies for who will provide a response.
+            return None
+
+        # Register event listener
+        _LOGGER.warning("Registering intent trigger")
+        if im := IntentsManager.get(self._hass):
+            command = self._options.get(CONF_COMMAND, "")
+            _LOGGER.warning(
+                "Registering intent trigger for intent %s with command: %s",
+                self._options[CONF_INTENT],
+                command,
+            )
+            self._unregister = im.register_trigger(
+                IntentTriggerDetails(
+                    intent=self._options[CONF_INTENT],
+                    command=command,
+                    callback=async_on_event,
+                )
+            )
+
+        return async_remove
+
+
+async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+    """Return triggers provided by this integration."""
+    _LOGGER.debug("Registering triggers for View Assist")
+    return {
+        "intent_trigger": VAIntentTrigger,
+    }


### PR DESCRIPTION
## In this PR

- Added a new view_assist.intent_tigger automation trigger that will fire on any defined intent firing.  See example automation 1
- Added VACustomIntent with optional command slot that can be used in custom sentence intent definitons and the automation trigger.  See example automation 2

## Notes
1. The trigger cannot yet be added via the UI and has to be done in yaml.  It also shows Unknown trigger in UI.
2. Any variables added in the automation become slots in the speech output and can be used in the intent response definition.  See example intent definitions (to be located in /config/custom_sentences/en).
3. Setting `set_conversation_response` will override any intent definition responses and respond with that sentence.
4. You will see in the example automation 1 that there is a var called trigger.display.  Our code has added this to the trigger to hold the sensor.xxxx linked to the conversation device.  We can add what ever we want in here that will be provided to each automation with this trigger.
5. It has some logging enabled as warning, but that is just for me to track as I develop, so you can not worry about it.


## Example Automation 1
```
alias: Weather Test
description: ""
triggers:
  - trigger: view_assist.intent_trigger
    options:
      intent: HassGetWeather
conditions: []
actions:
  - action: view_assist.navigate
    metadata: {}
    data:
      revert_timeout: 20
      device: "{{ trigger.display }}"
      path: /view-assist/weather
  - variables:
      weather_state: hot
  - set_conversation_response: This is a response from the automation!
    enabled: false
mode: single
```

## Example Automation 2
```
alias: VACustomIntent Test
description: ""
triggers:
  - trigger: view_assist.intent_trigger
    options:
      intent: VACustomIntent
      command: test_command
conditions: []
actions:
  - action: persistent_notification.create
    metadata: {}
    data:
      message: VACustom Intent Triggered for {{ trigger.slots.command }}
  - variables:
      good: "yes"
```

## Example Intent Definitions

### Extending an existing intent
```
# Example config/custom_sentences/en/hass_GetWeather.yaml
language: en
intents:
  HassGetWeather:
    data:
      - sentences:
          - "is it sunny outside"
          - "is it hot outside"
        response: scorchio

responses:
  intents:
    HassGetWeather:
      scorchio: "OMG! It is {{ state.attributes.get('temperature') }} {{ state.attributes.get('temperature_unit') }} and {{ slots.weather_state }} out there!"
```

### Using the VACustomIntent
```
# Example config/custom_sentences/en/colour_test.yaml
language: "en"
intents:
  VACustomIntent:
    data:
      - sentences:
          - "<is> {color} a good (color|colour)"
        slots:
          command: test_command
        response: color_response
      - sentences:
          - "do you like {color}"
        slots:
          command: test_command2
        response: color_like_response

responses:
  intents:
    VACustomIntent:
      default: "yes"
      color_response: |
        {% if slots.color == "green" %}
          No, {{ slots.color }} is not a good color!
        {% else %}
          Yes, {{ slots.color }} is a good color!
        {% endif %}
      color_like_response: |
        {% if slots.color == "green" %}
          No, I don't like {{ slots.color }}.
        {% else %}
          Yes, I like {{ slots.color }}!
        {% endif %}
```