### PR TITLE
Fix: Remove assets from version tracking if no longer in repo

### DIFF
--- a/custom_components/view_assist/devices/entity_listeners.py
+++ b/custom_components/view_assist/devices/entity_listeners.py
@@ -598,7 +598,7 @@ class EntityStateChangedHandler:
                     }
                 )
                 self._update_sensor_entity(updates)
-                if navigation_manager and word_count > 1:
+                if navigation_manager:
                     navigation_manager.browser_navigate("view-assist/info")
 
     @callback


### PR DESCRIPTION
## In this PR
This fixes an issue (caused by a change in 2025.11.0) whereby if a user has uninstalled a standard asset (ie those that are installed from the View Assist repo), prior to the asset being removed from the repo, they may get an update notification to install that asset.  When clicking install, they receive a 404 error that the asset does not exist.

This change will remove assets no longer available in the repo from the version tracking file when the version update routine runs (either every 2 hours or on manual call of the service), to stop this situation occuring.  It will also remove any existing update notification if it was created before this fix applied.