### PR TITLE
Fixed: intent hook registering and trigger stability

### DIFF
--- a/custom_components/view_assist/trigger.py
+++ b/custom_components/view_assist/trigger.py
@@ -40,7 +40,7 @@ _OPTIONS_SCHEMA = vol.Schema(
         vol.Required(CONF_INTENT): vol.All(
             cv.ensure_list, [cv.string], has_one_non_empty_item
         ),
-        vol.Optional(CONF_COMMAND): cv.string,
+        vol.Optional(CONF_COMMAND): vol.All(cv.ensure_list, [cv.string]),
     }
 )
 
@@ -78,7 +78,7 @@ class VAIntentTrigger(Trigger):
         @callback
         def async_remove() -> None:
             """Remove trigger."""
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Unregistering intent trigger -> %s - %s",
                 self._options[CONF_INTENT],
                 self._options.get(CONF_COMMAND),
@@ -141,18 +141,16 @@ class VAIntentTrigger(Trigger):
             return None
 
         # Register event listener
-        _LOGGER.warning("Registering intent trigger")
         if im := IntentsManager.get(self._hass):
-            command = self._options.get(CONF_COMMAND, "")
-            _LOGGER.warning(
-                "Registering intent trigger for intent %s with command: %s",
+            _LOGGER.debug(
+                "Registering intent trigger for intent %s with commands: %s",
                 self._options[CONF_INTENT],
-                command,
+                self._options.get(CONF_COMMAND),
             )
             self._unregister = im.register_trigger(
                 IntentTriggerDetails(
                     intents=self._options[CONF_INTENT],
-                    command=command,
+                    commands=self._options.get(CONF_COMMAND),
                     callback=async_on_event,
                 )
             )


### PR DESCRIPTION
## In this PR

- Now registers the IntentHookHandler for all intents after HA has started to ensure all other integrations have registered their intent handlers first
- Automations were triggering but response was None, caused by only running the first registered trigger.  When editing automations, you get a second registered trigger which hangs around for a while after, which if run returns nothing.  We now run all registered triggers and if it returns something we set that as the result.  When all triggers have run, we return the result.

**Note on trigger automations:**
As we can create as many automations as we want with the same triggers, and because we can pass back slots values and the conversation response from any of those automations, we will only return the values from the last automation to be called.  The order cannot be controlled so this could cause mismatched expectations of the automations that are running.  We should only have 1 automation per trigger.