### PR TITLE
fix: overlay top level is displayed even when staus is not in use

### DIFF
--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -48,7 +48,7 @@ JSMODULES = [
     {
         "name": "View Assist Helper",
         "filename": "view_assist.js",
-        "version": "1.0.23",
+        "version": "1.0.24",
     },
 ]
 # mins between checks for updated versions of dashboard and views

--- a/custom_components/view_assist/js_modules/view_assist.js
+++ b/custom_components/view_assist/js_modules/view_assist.js
@@ -1,6 +1,6 @@
-import { timerCards } from "./timers.js?v=1.0.23";
+import { timerCards } from "./timers.js?v=1.0.24";
 
-const version = "1.0.23"
+const version = "1.0.24"
 const TIMEOUT_ERROR = "SELECTTREE-TIMEOUT";
 
 export async function await_element(el, hard = false) {
@@ -741,7 +741,7 @@ class ViewAssist {
 
       const divs = { "listening": listeningDiv, "processing": processingDiv, "responding": respondingDiv };
 
-      if (state in divs) {
+      if (state in divs && divs[state] != null) {
         styleDiv.style.display = "block";
       } else {
         styleDiv.style.display = "none";


### PR DESCRIPTION
## In this PR 

We introduced a small bug in the overlays on the last update.  With the now 3 possible statuses to show an overlay of listening, processing, responding, it will display the top level div on any of those statuses.

On the overlays with bluring backgrounds, this causes the blur background to show on every status, even if that status is not is use.

This check that the status is in use resolves that.