### PR TITLE
feat: add configurable cycle views

### DIFF
--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -38,6 +38,7 @@ from .const import (
     CONF_BACKGROUND,
     CONF_BACKGROUND_MODE,
     CONF_BACKGROUND_SETTINGS,
+    CONF_CYCLE_VIEWS,
     CONF_DASHBOARD,
     CONF_DEVELOPER_DEVICE,
     CONF_DEVELOPER_MIMIC_DEVICE,
@@ -305,6 +306,15 @@ async def get_dashboard_options_schema(
                 options=[e.value for e in VAScreenMode],
                 mode=SelectSelectorMode.DROPDOWN,
                 translation_key="lookup_selector",
+            )
+        ),
+        vol.Optional(CONF_CYCLE_VIEWS): SelectSelector(
+            SelectSelectorConfig(
+                translation_key="cycle_views_selector",
+                options=[],
+                mode=SelectSelectorMode.LIST,
+                multiple=True,
+                custom_value=True,
             )
         ),
     }

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -110,6 +110,7 @@ CONF_MENU_ITEMS = "menu_items"
 CONF_MENU_TIMEOUT = "menu_timeout"
 CONF_TIME_FORMAT = "time_format"
 CONF_SCREEN_MODE = "screen_mode"
+CONF_CYCLE_VIEWS = "cycle_views"
 
 CONF_WEATHER_ENTITY = "weather_entity"
 CONF_VIEW_TIMEOUT = "view_timeout"
@@ -160,6 +161,7 @@ DEFAULT_VALUES = {
         CONF_MENU_TIMEOUT: 10,
         CONF_TIME_FORMAT: VATimeFormat.HOUR_12,
         CONF_SCREEN_MODE: VAScreenMode.HIDE_HEADER_SIDEBAR,
+        CONF_CYCLE_VIEWS: CYCLE_VIEWS,
     },
     # Default options
     CONF_WEATHER_ENTITY: "weather.home",

--- a/custom_components/view_assist/devices/entity_listeners.py
+++ b/custom_components/view_assist/devices/entity_listeners.py
@@ -26,7 +26,6 @@ from homeassistant.helpers.event import async_track_state_change_event
 from ..assets import AssetClass, AssetsManager  # noqa: TID252
 from ..const import (  # noqa: TID252
     CC_CONVERSATION_ENDED_EVENT,
-    CYCLE_VIEWS,
     CONF_MUSIC_MODE_AUTO,
     CONF_MUSIC_MODE_TIMEOUT,
     DEVICES,
@@ -435,7 +434,8 @@ class SensorAttributeChangedHandler:
         elif new_mode == VAMode.CYCLE:
             # Start cycling views
             if self.navigation_manager:
-                self.navigation_manager.start_display_view_cycle(CYCLE_VIEWS)
+                cycle_views = self.config.runtime_data.dashboard.display_settings.cycle_views
+                self.navigation_manager.start_display_view_cycle(cycle_views)
 
         elif new_mode == VAMode.HOLD:
             # Hold mode, so cancel any revert timer

--- a/custom_components/view_assist/translations/en.json
+++ b/custom_components/view_assist/translations/en.json
@@ -125,7 +125,8 @@
               "menu_items": "Menu items",
               "menu_timeout": "Menu timeout",
               "time_format": "Time format",
-              "screen_mode": "Show/hide header and sidebar"
+              "screen_mode": "Show/hide header and sidebar",
+              "cycle_views": "Cycle views"
             },
             "data_description": {
               "assist_prompt": "The Assist notification prompt style to use for wake word detection and intent processing",
@@ -136,7 +137,8 @@
               "menu_items": "List of items to show in the menu when activated",
               "menu_timeout": "Time in seconds before menu automatically closes (0 to disable timeout)",
               "time_format": "Sets clock display time format",
-              "screen_mode": "Show or hide the header and sidebar"
+              "screen_mode": "Show or hide the header and sidebar",
+              "cycle_views": "List of items to show when in cycle mode"
             }
           }
         }

--- a/custom_components/view_assist/typed.py
+++ b/custom_components/view_assist/typed.py
@@ -135,6 +135,7 @@ class DisplayConfig:
     menu_timeout: int = 10
     time_format: VATimeFormat | None = None
     screen_mode: VAScreenMode | None = None
+    cycle_views: list[str] = field(default_factory=list)
 
 
 @dataclass


### PR DESCRIPTION
The `cycle` mode currently uses a hard coded list of values, this allows the UI to configure what those views should be.

- New Property `cycle_views`
- Default value: `["music", "info", "weather", "clock"]`