### PR TITLE
Runtime config overrides

### DIFF
--- a/custom_components/view_assist/core/websocket.py
+++ b/custom_components/view_assist/core/websocket.py
@@ -298,7 +298,9 @@ class WebsocketListenerHandler:
                     "timers": timer_info,
                     "background": data.dashboard.background_settings.background,
                     "dashboard": data.dashboard.dashboard,
-                    "home": data.dashboard.home,
+                    "home": data.dashboard.home
+                    if not data.runtime_config_overrides.home
+                    else data.runtime_config_overrides.home,
                     "music": data.dashboard.music,
                     "intent": data.dashboard.intent,
                     "hide_sidebar": data.dashboard.display_settings.screen_mode

--- a/custom_components/view_assist/devices/entity_listeners.py
+++ b/custom_components/view_assist/devices/entity_listeners.py
@@ -311,6 +311,12 @@ class AssistEntityListenerHandler:
             elif state in ["start", "intent-processing"]:
                 state = AssistSatelliteState.PROCESSING
 
+            assist_prompt = (
+                self.config.runtime_data.dashboard.display_settings.assist_prompt
+                if not self.config.runtime_data.runtime_config_overrides.assist_prompt
+                else self.config.runtime_data.runtime_config_overrides.assist_prompt
+            )
+
             async_dispatcher_send(
                 self.hass,
                 f"{DOMAIN}_{self.config.entry_id}_event",
@@ -318,7 +324,7 @@ class AssistEntityListenerHandler:
                     VAEventType.ASSIST_LISTENING,
                     {
                         "state": state,
-                        "style": self.config.runtime_data.dashboard.display_settings.assist_prompt,
+                        "style": assist_prompt,
                     },
                 ),
             )
@@ -417,9 +423,7 @@ class SensorAttributeChangedHandler:
         if new_mode == VAMode.NORMAL:
             # Add navigate to default view
             if self.navigation_manager:
-                self.navigation_manager.browser_navigate(
-                    self.config.runtime_data.dashboard.home
-                )
+                self.navigation_manager.navigate_home()
         elif new_mode == VAMode.MUSIC:
             # Add navigate to music view
             if self.navigation_manager:

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import DOMAIN, OPTION_KEY_MIGRATIONS
 from .core import TimerManager
-from .devices import MenuManager
+from .devices import MenuManager, NavigationManager
 from .helpers import get_device_id_from_entity_id, get_mute_switch_entity_id
 from .typed import (
     DISPLAY_DEVICE_TYPES,
@@ -126,7 +126,12 @@ class ViewAssistSensor(SensorEntity):
                 self._attr_native_value = v
                 continue
 
-            # TODO: Update runtime config data types as needed
+            # Specific overrides
+            if hasattr(self.config.runtime_data.runtime_config_overrides, k):
+                if getattr(self.config.runtime_data.runtime_config_overrides, k) != v:
+                    setattr(self.config.runtime_data.runtime_config_overrides, k, v)
+                    update_ha = True
+                continue
 
             # Set the value of named vartiables or add/update to extra_data dict
             if hasattr(self.config.runtime_data.default, k):
@@ -160,6 +165,9 @@ class ViewAssistSensor(SensorEntity):
         # Display device settings
         if self._type in DISPLAY_DEVICE_TYPES:
             attrs.update(self._get_display_device_status_attributes())
+
+        # Active overrides
+        attrs["active_overrides"] = self._get_active_overrides_attributes()
 
         # Add extra_data attributes from runtime data
         attrs.update(self.config.runtime_data.extra_data)
@@ -214,3 +222,13 @@ class ViewAssistSensor(SensorEntity):
             "view_timeout": d.default.view_timeout,
             "weather_entity": d.default.weather_entity,
         }
+
+    def _get_active_overrides_attributes(self) -> dict[str, Any]:
+        """Build active runtime override attributes dictionary."""
+        d = self.config.runtime_data.runtime_config_overrides
+        attrs = {}
+        if d.home is not None and d.home != "":
+            attrs["home"] = d.home
+        if d.assist_prompt is not None and d.assist_prompt != "":
+            attrs["assist_prompt"] = d.assist_prompt
+        return attrs

--- a/custom_components/view_assist/typed.py
+++ b/custom_components/view_assist/typed.py
@@ -170,6 +170,14 @@ class DeveloperConfig:
     developer_mimic_device: str | None = None
 
 
+@dataclass
+class RuntimeConfigOverrides:
+    """Class to hold runtime override data."""
+
+    home: str | None = None
+    assist_prompt: str | None = None
+
+
 class MasterConfigRuntimeData:
     """Class to hold master config data."""
 
@@ -191,6 +199,7 @@ class DeviceRuntimeData:
         self.core: DeviceCoreConfig = DeviceCoreConfig()
         self.dashboard: DashboardConfig = DashboardConfig()
         self.default: DefaultConfig = DefaultConfig()
+        self.runtime_config_overrides: RuntimeConfigOverrides = RuntimeConfigOverrides()
 
         # Extra data for holding key/value pairs passed in by set_state service call
         self.extra_data: dict[str, Any] = {}


### PR DESCRIPTION
## In this PR

Added: Ability to set runtime overrides for home and assist_prompt
Added: Ability to pass home as the path to navigation service and it will navigate to home path
Minor bug fix: if device is offline when HA starts, it was throwing an error trying to setup entity listeners.  This prevents error

### Notes:

**Home Override:** This will set the home view until restart or clearing.  Anytime the device is navigated to a page, it will revert to the overriden home page.  Set this to "" to clear the override.
**Assist Popup Override:** This will set the assist_popup until restart or clearing.  Anytime the popup is shown, it will use what is set here.  The popup value should be the popup id as defined in overlay.html.  It can also be set to "None" to show no assist popup.  Set this to "" to clear the override.


### Examples
Setting
```
action: view_assist.set_state
target:
  entity_id: sensor.echo_show_8
data:
  home: "/view-assist/testview"
  assist_popup: "kitt_bar"
```
Clearing
```
action: view_assist.set_state
target:
  entity_id: sensor.echo_show_8
data:
  assist_popup: ""
```



To navigate to home page set path to "home".  Ie
```
action: view_assist.navigate
data:
  device: sensor.echo_show_8
  path: home
```
