### PR TITLE
refactor(sensor): simplify orientation_sensor attribute access in sensor attributes

### DIFF
--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -185,7 +185,7 @@ class ViewAssistSensor(SensorEntity):
             "mute_switch": get_mute_switch_entity_id(self.hass, d.mic_device),
             "display_device": d.display_device,
             "intent_device": d.intent_device,
-            "orientation_sensor": self.config.runtime_data.core.orientation_sensor,
+            "orientation_sensor": d.orientation_sensor,
             "mediaplayer_device": d.mediaplayer_device,
             "musicplayer_device": d.musicplayer_device,
             "voice_device_id": get_device_id_from_entity_id(self.hass, d.mic_device),


### PR DESCRIPTION
### Description
Maintains consistency with other device properties in the same method (mic_device, display_device, etc.) which all use the `d` shorthand. Since `d = self.config.runtime_data.core`, functionality is identical.

### Changes
- Use `d.orientation_sensor` instead of `self.config.runtime_data.core.orientation_sensor` in `_get_core_attributes()`