### PR TITLE
fix(navigation): use configured home view in navigate_home()

### DIFF
--- a/custom_components/view_assist/devices/navigation.py
+++ b/custom_components/view_assist/devices/navigation.py
@@ -162,7 +162,7 @@ class NavigationManager:
         path = (
             self.config.runtime_data.runtime_config_overrides.home
             if self.config.runtime_data.runtime_config_overrides.home
-            else self.config.runtime_data.dashboard.dashboard
+            else self.config.runtime_data.dashboard.home
         )
         self.browser_navigate(
             path=path,


### PR DESCRIPTION
Fixed bug where navigate_home() was falling back to dashboard.dashboard instead of dashboard.home when no runtime override is set. This caused mode changes to NORMAL to navigate to the base dashboard path instead of the configured home view.

Should fix the issue discord user or1as is experiencing with being incorrectly navigated to /view-assist/clock despite having configured a different home view in their settings.