### PR TITLE
fix(music-mode): use runtime_data for music mode config

### DIFF
--- a/custom_components/view_assist/devices/entity_listeners.py
+++ b/custom_components/view_assist/devices/entity_listeners.py
@@ -453,8 +453,8 @@ class EntityStateChangedHandler:
         self.entity_id: str | None = None
 
         # Music mode auto-switching configuration
-        self.music_mode_auto = config.options.get(CONF_MUSIC_MODE_AUTO, False)
-        self.music_mode_timeout = config.options.get(CONF_MUSIC_MODE_TIMEOUT, 300)
+        self.music_mode_auto = config.runtime_data.default.music_mode_auto or False
+        self.music_mode_timeout = config.runtime_data.default.music_mode_timeout or 300
         self.music_timeout_task: asyncio.Task | None = None
 
     def register_listeners(self) -> None:


### PR DESCRIPTION
Music mode auto switching was reading configuration directly from device options instead of from runtime_data.default, which contains the properly merged master and device configuration.

EntityStateChangedHandler now reads music_mode_auto and music_mode_timeout from config.runtime_data.default instead of config.options

Fixes https://github.com/dinki/View-Assist/issues/295