### PR TITLE
feat(sensor): expose screen_mode as entity attribute

### DIFF
--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -222,6 +222,7 @@ class ViewAssistSensor(SensorEntity):
             "mode": d.default.mode,
             "view_timeout": d.default.view_timeout,
             "weather_entity": d.default.weather_entity,
+            "screen_mode": self.config.runtime_data.dashboard.display_settings.screen_mode,
         }
 
     def _get_active_overrides_attributes(self) -> dict[str, Any]:


### PR DESCRIPTION
Adds screen_mode to the sensor's extra_state_attributes to make the display configuration setting accessible to the frontend dashboard. This enables conditional UI rendering based on whether the header and sidebar are visible or hidden for each device.