### PR TITLE
Add home screen attribute to sensor

### DIFF
--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -278,7 +278,9 @@ class ViewAssistSensor(RestoreSensor):
             "mode": d.default.mode,
             "view_timeout": d.default.view_timeout,
             "weather_entity": d.default.weather_entity,
-            "screen_mode": self.config.runtime_data.dashboard.display_settings.screen_mode,
+            "screen_mode": d.dashboard.display_settings.screen_mode,
+            "home_screen": d.runtime_config_overrides.home if
+            d.runtime_config_overrides.home else d.dashboard.home,
         }
 
     def _get_active_overrides_attributes(self) -> dict[str, Any]:


### PR DESCRIPTION
Exposes the configured home screen path (including runtime overrides) as a `home_screen` attribute in display device status attributes.

This allows the dashboard to dynamically determine which view is the home view, enabling proper icon visibility management.
Can also be beneficial for future troubleshooting assistance.

Related: dinki/View-Assist/pull/367