### PR TITLE
Fix: browser_id not correctly updated when changed in VACA

### DIFF
--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -48,7 +48,7 @@ JSMODULES = [
     {
         "name": "View Assist Helper",
         "filename": "view_assist.js",
-        "version": "1.0.25",
+        "version": "1.0.27",
     },
 ]
 # mins between checks for updated versions of dashboard and views

--- a/custom_components/view_assist/core/timers.py
+++ b/custom_components/view_assist/core/timers.py
@@ -1109,7 +1109,9 @@ class TimerManagerServices:
             else:
                 raise vol.InInvalid("entity_id or device_id is required")
 
-        extra_info = {"sentence": sentence}
+        extra_info = {
+            "sentence": sentence.replace("-", " ")
+        }  # Google STT can add - in interval sentence.
         if extra_data:
             extra_info.update(extra_data)
 

--- a/custom_components/view_assist/core/translator/translator.py
+++ b/custom_components/view_assist/core/translator/translator.py
@@ -37,6 +37,9 @@ class LangPackKeys2(StrEnum):
     DECIMAL_SEPARATOR = "decimal_separator"
 
 
+CLEAN_SYMBOLS = ["-", "_"]
+
+
 PROJECT_ID = environ.get("PROJECT_ID", "")
 
 
@@ -175,6 +178,11 @@ class TimeSentenceTranslator:
     def clean_sentence(self, s: str) -> str:
         """Preprocess sentence to remove and replace words/text/symbols."""
         s = f" {s.lower().strip()} "
+
+        # Remove unwanted symbols - fix for Goolge STT hyphenating interval times like 5-minutes
+        for sym in CLEAN_SYMBOLS:
+            s = s.replace(sym, " ")
+
         # Replace decimal separator with .
         if sep := self.lang.get(LangPackKeys2.DECIMAL_SEPARATOR):
             pattern = rf"(\d+){re.escape(sep)}(\d+)"

--- a/custom_components/view_assist/js_modules/view_assist.js
+++ b/custom_components/view_assist/js_modules/view_assist.js
@@ -1,6 +1,6 @@
-import { timerCards } from "./timers.js?v=1.0.25";
+import { timerCards } from "./timers.js?v=1.0.27";
 
-const version = "1.0.25"
+const version = "1.0.27"
 const TIMEOUT_ERROR = "SELECTTREE-TIMEOUT";
 
 export async function await_element(el, hard = false) {
@@ -523,20 +523,25 @@ class ViewAssist {
   }
 
   get_browser_id() {
-    // Create a browser id if not already set
-    if (!localStorage.getItem("view_assist_browser_id")) {
-      // Test if VA Companion App is installed and get uuid from that
-      let browser_id = '';
-      try {
-        browser_id = `va-${ViewAssistApp.getViewAssistCAUUID()}`;
-      } catch (e) {
-        const s4 = () => { return Math.floor((1 + Math.random()) * 100000).toString(16).substring(1); };
-        browser_id = `va-${s4()}${s4()}-${s4()}${s4()}`
-      }
-      localStorage.setItem("view_assist_browser_id", browser_id);
-      return browser_id
+    let updateBrowserId = ''
+    const storedBrowserId = localStorage.getItem("view_assist_browser_id");
+    let vaca_browser_id = '';
+    try {
+      vaca_browser_id = `va-${ViewAssistApp.getViewAssistCAUUID()}`;
+    } catch (e) { }
+
+    if (vaca_browser_id && vaca_browser_id != storedBrowserId) {
+      updateBrowserId = vaca_browser_id;
+    } else if (!storedBrowserId) {
+      const s4 = () => { return Math.floor((1 + Math.random()) * 100000).toString(16).substring(1); };
+      updateBrowserId = `va-${s4()}${s4()}-${s4()}${s4()}`;
     }
-    return localStorage.getItem("view_assist_browser_id");
+
+    if (updateBrowserId) {
+      localStorage.setItem("view_assist_browser_id", updateBrowserId);
+      return updateBrowserId;
+    }
+    return storedBrowserId;
   }
 
   async connect(attempts = 1) {


### PR DESCRIPTION
As description, this is a change to the js helper to update the browser_id held in localStorage if changed in VACA.  Previsouly, this changed on the VACA device but did not update in the browser storage, therefore the device still identified in VA as the old id.