### PR TITLE
fix: readd configurable cycle modes

### DIFF
--- a/custom_components/view_assist/devices/entity_listeners.py
+++ b/custom_components/view_assist/devices/entity_listeners.py
@@ -435,7 +435,8 @@ class SensorAttributeChangedHandler:
         elif new_mode == VAMode.CYCLE:
             # Start cycling views
             if self.navigation_manager:
-                self.navigation_manager.start_display_view_cycle(CYCLE_VIEWS)
+                cycle_views = self.config.runtime_data.dashboard.display_settings.cycle_views
+                self.navigation_manager.start_display_view_cycle(cycle_views)
 
         elif new_mode == VAMode.HOLD:
             # Hold mode, so cancel any revert timer


### PR DESCRIPTION
Noticed this was reverted in https://github.com/dinki/view_assist_integration/commit/4c4db038e572049292ad6c6f492054e5d8ebb71e so putting in a request to add this back in for some use cases I have (WAF).  Wasn't sure if this was reverted on purpose, accidentally, or just overlooked in a merge.

Fixes https://github.com/dinki/View-Assist/issues/397