### PR TITLE
Fix: Improve handling and recovery from server connection loss

### DIFF
--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -48,7 +48,7 @@ JSMODULES = [
     {
         "name": "View Assist Helper",
         "filename": "view_assist.js",
-        "version": "1.0.28",
+        "version": "1.0.29",
     },
 ]
 # mins between checks for updated versions of dashboard and views

--- a/custom_components/view_assist/core/websocket.py
+++ b/custom_components/view_assist/core/websocket.py
@@ -78,21 +78,17 @@ class WebsocketManager:
         """Register a new connection."""
 
         # Add to known browser ids list
-        if (
-            str(browser_id).startswith("va-")
-            and browser_id not in self.hass.data[DOMAIN][BROWSER_IDS]
-        ):
+        if (browser_id).startswith("va-"):
+            # Ensure not registering duplicate connection
+            self.unregister_connection(browser_id)
+
+            # Add to known browser ids list
             self.hass.data[DOMAIN][BROWSER_IDS][browser_id] = browser_id
 
-        # Register handler for connection
-        handler = WebsocketListenerHandler(self.hass, connection, browser_id, msg_id)
-
-        # If duplicate connection, stop old one
-        if browser_id in self.connections:
-            self.connections[browser_id].stop()
-
-        self.connections[browser_id] = handler
-        handler.start()
+            self.connections[browser_id] = WebsocketListenerHandler(
+                self.hass, connection, browser_id, msg_id
+            )
+            self.connections[browser_id].start()
 
     def unregister_connection(self, browser_id: str, unloading: bool = False):
         """Unregister a connection."""
@@ -336,7 +332,6 @@ def setup_websocket_commands(hass: HomeAssistant) -> None:
 
         def close_connection():
             _LOGGER.debug("Browser with id %s disconnected", browser_id)
-            WebsocketManager.get(hass).unregister_connection(browser_id)
 
         # Register browser
         await WebsocketManager.get(hass).async_register_connection(

--- a/custom_components/view_assist/js_modules/view_assist.js
+++ b/custom_components/view_assist/js_modules/view_assist.js
@@ -1,6 +1,6 @@
 import { timerCards } from "./timers.js?v=1.0.28";
 
-const version = "1.0.29"
+const version = "1.0.29-rc2"
 const TIMEOUT_ERROR = "SELECTTREE-TIMEOUT";
 
 export async function await_element(el, hard = false) {
@@ -509,6 +509,7 @@ class ViewAssist {
           if (ev.detail != "connected") {
             console.log("View Assist - Connection lost");
             this.connected = false;
+            this.hide_all_overlays();
             clearInterval(this.serverTimeHandler)
           } else {
             if (!this.connected) {
@@ -740,6 +741,23 @@ class ViewAssist {
     }
 
     htmlElement.shadowRoot.appendChild(st);
+  }
+
+  async hide_all_overlays() {
+    try {
+      let overlays = await selectTree(
+        document.body,
+        "view-assist-overlays $"
+      );
+
+      overlays.querySelectorAll("*").forEach((div) => {
+        if (div.getAttribute("data-name") != null) {
+          div.style.display = "none";
+        }
+      });
+    } catch (e) {
+      console.log("Error hiding overlays: ", e);
+    }
   }
 
   async show_assist_listening_overlay(state, style) {

--- a/custom_components/view_assist/js_modules/view_assist.js
+++ b/custom_components/view_assist/js_modules/view_assist.js
@@ -599,7 +599,7 @@ class ViewAssist {
     const payload = msg["payload"];
     const is_mimic = this.variables.config?.mimic_device;
 
-    console.log("Event: " + event + ", Payload: " + JSON.stringify(payload));
+    //console.log("Event: " + event + ", Payload: " + JSON.stringify(payload));
 
     switch (event) {
       case "registered":

--- a/custom_components/view_assist/js_modules/view_assist.js
+++ b/custom_components/view_assist/js_modules/view_assist.js
@@ -1,6 +1,6 @@
 import { timerCards } from "./timers.js?v=1.0.28";
 
-const version = "1.0.28"
+const version = "1.0.29"
 const TIMEOUT_ERROR = "SELECTTREE-TIMEOUT";
 
 export async function await_element(el, hard = false) {
@@ -507,10 +507,13 @@ class ViewAssist {
       if (this.connected) {
         window.addEventListener("connection-status", (ev) => {
           if (ev.detail != "connected") {
-            this.connect()
-          } else {
+            console.log("View Assist - Connection lost");
             this.connected = false;
             clearInterval(this.serverTimeHandler)
+          } else {
+            if (!this.connected) {
+              this.connect();
+            }
           }
         });
 
@@ -568,10 +571,12 @@ class ViewAssist {
         epoch: new Date().getTime()
       })
       this.connected = true;
-    } catch {
+      console.log("View Assist - Connected to server");
+    } catch (error) {
+      console.log("View Assist - Unable to connect to server - " + error.message + ". Retrying in 2s. Attempt: " + attempts);
       this.connected = false;
-      if (attempts < 50) {
-        setTimeout(() => this.connect(attempts + 1), 500);
+      if (attempts < 60) {
+        setTimeout(() => this.connect(attempts + 1), 2000);
       } else {
         console.log("View Assist - Unable to connect to server")
       }
@@ -593,7 +598,7 @@ class ViewAssist {
     const payload = msg["payload"];
     const is_mimic = this.variables.config?.mimic_device;
 
-    //console.log("Event: " + event + ", Payload: " + JSON.stringify(payload));
+    console.log("Event: " + event + ", Payload: " + JSON.stringify(payload));
 
     switch (event) {
       case "registered":


### PR DESCRIPTION
In this PR are fixes for the following issues

- When the device loses connection to the HA server (caused by server restart or wifi disconnection), the websocket connection (which handles all the display based commands like show/hide overlays, show/hide menus, navigation etc) can fail to reconnect.  This PR changes the handling in the javascript helper to reconnect when the main HA websocket announces its reconnection.  It also drops the retry interval from 0.5s to 2s to prevent log spamming.

- When recovering from a connection loss, the javascript can connect multiple times and then disconnect one of the connections at the end.  The code assumed only 1 connection and therefore the disconnect can leave the connection in a dead state.  The PR changes this to always keep a connection open once established and only close an existing one if a new connection comes in.

- When a connection to the server is lost during a voice interaction, it can leave the overlay displaying with no way to remove that without starting a new interaction.  This PR will hide all overlays if the websocket disconnects.