### PR TITLE
Fix duration parsing for hyphenated numbers and decimals

### DIFF
--- a/custom_components/view_assist/core/timers.py
+++ b/custom_components/view_assist/core/timers.py
@@ -1088,9 +1088,11 @@ class TimerManagerServices:
         else:
             time_type = "interval"
             
-        # Some STT add additional chars.  This removes those that add - or .
+        # Some STT returns durations hyphenated ("5-minute", "forty-five").
+        # Replace those with space and preserve periods to support decimals,
+        # e.g. "2.5"
         if timer_time:
-            timer_time = timer_time.replace("-", "").replace(".", "")
+            timer_time = timer_time.replace("-", " ")
         
         sentence, timer_info = await self.decode_time_sentence(
             timer_time, language=language, time_type=time_type

--- a/custom_components/view_assist/core/translator/wordstonumbers.py
+++ b/custom_components/view_assist/core/translator/wordstonumbers.py
@@ -51,6 +51,9 @@ class WordsToDigits:
 
         units = "one|two|three|four|five|six|seven|eight|nine"
 
+        # Convert hyphenated compounds (e.g. "forty-five") to space-separated.
+        s = re.sub(rf"\b({tens})-?({units})\b", r"\1 \2", s)
+
         word_pattern = rf"(?:^|\s)({tens}) ({units})(?:$|\s)"
         if matches := re.findall(word_pattern, s):
             for m in matches:


### PR DESCRIPTION
This PR fixes two bugs in the duration parsing when creating timers.

## Bug 1 - Decimals

The fix for dinki/view_assist_integration#245, in a addition to stripping hyphens (`-`), also stripped periods (`.`). This caused the integer part and the fractal part of the input to get combined, e.g. "2.5" becomes "25".

| Input sentence | Actual timer created | Expected timer created
|--------|--------|--------|
| "Set a timer for 2.5 minutes" | 25 minutes :x:  | 2 minutes 30 seconds |
| "Set a timer for 1.5 hours" | 15 hours :x: |  1 hour 30 minutes |


## Bug 2 - Hyphenated Numbers

Some STT hyphenate compound numbers. For example "forty-five", "sixty-nine", "5-minute", etc.

The fix for dinki/view_assist_integration#245 completely deleted hyphens (`-`) so "forty-five" became "fortyfive", "sixty-nine" became "sixtynine", etc. But `WordsToDigit.convert` only joins tens and units across a literal space (` `).

This caused duration decoding to fail with "Unable to decode time or interval information".

| Input | After stripping | Result |
|------|-----------------|--------|
| `forty minutes` | `forty minutes` | 40 minutes ✅ |
| `forty-five minutes` | `fortyfive minutes` | **fail** ❌ |
| `twenty-five minutes` | `twentyfive minutes`| **fail** ❌ |


## The Fix

Instead of deleting hyphens completely, they get replaced with a space because the [duration pattern](https://github.com/dinki/view_assist_integration/blob/a4da6923d967bcbf4b12a728560fe9268233cd4b/custom_components/view_assist/core/translator/normaliser.py#L86) already supports an optional space separator. 
Decimal points are left alone not break fractions (e.g. "2.5").

### Result

| Input | Before | After |
|-------|--------|-------|
| `5-minute` | 5 minutes ✅ | 5 minutes ✅ |
| `10-second` | 10 seconds ✅ | 10 seconds ✅ |
| `2.5 minutes` | 25 minutes ❌ | 2 minutes 30 seconds ✅ |
| `forty-five minutes` | fail ❌ | 45 minutes ✅ |
| `twenty-five minutes`| fail ❌ | 25 minutes ✅ |
| `five minutes` | 5 minutes ✅ | 5 minutes ✅ |
| `1 hour and 30 minutes` | 1h30m ✅ | 1h30m ✅ |

## Testing

I tested it in my Home Assistant using ElevenLabs STT and also by calling `view_assist.set_timer` with
each input above and checking the created timer's duration. 