### PR TITLE
fix: keep volume changes made whilst ducked

### DIFF
--- a/custom_components/view_assist/devices/entity_listeners.py
+++ b/custom_components/view_assist/devices/entity_listeners.py
@@ -11,7 +11,7 @@ from awesomeversion import AwesomeVersion
 # pylint: disable-next=hass-component-root-import
 from homeassistant.components.assist_satellite.entity import AssistSatelliteState
 from homeassistant.components.media_player import MediaPlayerState
-from homeassistant.const import STATE_ON
+from homeassistant.const import EVENT_CALL_SERVICE, STATE_ON
 from homeassistant.core import (
     Context,
     Event,
@@ -53,8 +53,11 @@ from .navigation import NavigationManager
 
 _LOGGER = logging.getLogger(__name__)
 
-# Allows for players rounding volume, whilst below the 0.1 volume_up/down step
-DUCKING_VOLUME_TOLERANCE = 0.02
+# Volume difference small enough to be float noise rather than a real change
+DUCKING_VOLUME_TOLERANCE = 0.005
+
+# Time to let the music player report the volume it was actually ducked to
+DUCKING_SETTLE_TIME = 0.5
 
 
 class EntityListeners:
@@ -103,6 +106,9 @@ class AssistEntityListenerHandler:
         self.music_player_entity = config.runtime_data.core.musicplayer_device
         self.music_player_volume: float = 0.0
         self.ducked_volume: float | None = None
+        self.ducked_volume_set: float | None = None
+        self.set_volume_whilst_ducked: float | None = None
+        self.own_volume_call_ids: set[str] = set()
         self.is_ducked: bool = False
         self.ducking_task: asyncio.Task | None = None
 
@@ -130,6 +136,12 @@ class AssistEntityListenerHandler:
                     self.hass, assist_entity_id, self.on_state_change
                 )
             )
+            if self.music_player_entity:
+                self.config.async_on_unload(
+                    self.hass.bus.async_listen(
+                        EVENT_CALL_SERVICE, self._async_on_volume_service_call
+                    )
+                )
         else:
             _LOGGER.warning(
                 "Unable to find entity for pipeline status for %s",
@@ -166,6 +178,60 @@ class AssistEntityListenerHandler:
             self.hass,
             self.do_volume_ducking(old_state.state, new_state.state),
             name="VA Volume Ducking Task",
+        )
+
+    @callback
+    def _async_on_volume_service_call(self, event: Event) -> None:
+        """Note volume_set calls to the music player made whilst ducked."""
+        if not self.is_ducked or event.context.id in self.own_volume_call_ids:
+            return
+        if (
+            event.data.get("domain") != "media_player"
+            or event.data.get("service") != "volume_set"
+        ):
+            return
+
+        service_data = event.data.get("service_data", {})
+        entity_id = service_data.get("entity_id")
+        entity_ids = [entity_id] if isinstance(entity_id, str) else entity_id or []
+        if self.music_player_entity not in entity_ids:
+            return
+
+        if (volume := service_data.get("volume_level")) is not None:
+            _LOGGER.debug("Volume of music player set to %s whilst ducked", volume)
+            self.set_volume_whilst_ducked = float(volume)
+
+    def _volume_changed_whilst_ducked(self, volume: float | None) -> bool:
+        """Check if a volume differs from the level the player was ducked to."""
+        if volume is None:
+            return False
+
+        # Compare against both the volume asked for and the volume reported back, as
+        # a player rounding the volume it was set to is not a change in itself
+        ducked_volumes = [
+            ducked
+            for ducked in (self.ducked_volume, self.ducked_volume_set)
+            if ducked is not None
+        ]
+        return bool(ducked_volumes) and all(
+            abs(volume - ducked) > DUCKING_VOLUME_TOLERANCE for ducked in ducked_volumes
+        )
+
+    async def _async_set_music_player_volume(
+        self, volume: float, blocking: bool = False
+    ) -> None:
+        """Set the music player volume, marking the call as our own."""
+        context = Context()
+        self.own_volume_call_ids.add(context.id)
+        await self.hass.services.async_call(
+            "media_player",
+            "volume_set",
+            {
+                "entity_id": self.music_player_entity,
+                "volume_level": volume,
+            },
+            blocking=blocking,
+            context=context,
         )
 
     async def do_volume_ducking(self, old_state: str, new_state: str) -> None:
@@ -238,16 +304,20 @@ class AssistEntityListenerHandler:
 
                 if self.music_player_volume > ducking_volume:
                     _LOGGER.debug("Ducking music player volume to: %s", ducking_volume)
-                    await self.hass.services.async_call(
-                        "media_player",
-                        "volume_set",
-                        {
-                            "entity_id": self.music_player_entity,
-                            "volume_level": ducking_volume,
-                        },
-                    )
+                    await self._async_set_music_player_volume(ducking_volume)
                     self.is_ducked = True
-                    self.ducked_volume = ducking_volume
+                    self.ducked_volume = self.ducked_volume_set = ducking_volume
+
+                    # Players round the volume they are set to, so use the volume
+                    # reported back as the level to compare against later
+                    await asyncio.sleep(DUCKING_SETTLE_TIME)
+                    if (
+                        ducked_state := self.hass.states.get(self.music_player_entity)
+                    ) and (
+                        reported := ducked_state.attributes.get("volume_level")
+                    ) is not None:
+                        _LOGGER.debug("Music player ducked to: %s", reported)
+                        self.ducked_volume = float(reported)
 
             else:
                 _LOGGER.debug(
@@ -283,36 +353,36 @@ class AssistEntityListenerHandler:
                         "volume_level"
                     )
 
-                    # Volume changed while ducked, so that is now the wanted volume
-                    if (
-                        self.ducked_volume is not None
-                        and current_music_player_volume is not None
-                        and abs(current_music_player_volume - self.ducked_volume)
-                        > DUCKING_VOLUME_TOLERANCE
-                    ):
-                        _LOGGER.debug(
-                            "Music player volume changed to %s while ducked "
-                            "(expected %s), skipping restore",
-                            current_music_player_volume,
-                            self.ducked_volume,
+                    if self._volume_changed_whilst_ducked(current_music_player_volume):
+                        # An absolute volume was asked for, so leave it alone
+                        if self.set_volume_whilst_ducked is not None:
+                            _LOGGER.debug(
+                                "Music player volume set to %s whilst ducked, "
+                                "skipping restore",
+                                current_music_player_volume,
+                            )
+                            self._reset_ducking_state()
+                            return
+
+                        # Volume was stepped up or down from the ducked level, so
+                        # apply that same step to the volume from before ducking
+                        step = current_music_player_volume - (self.ducked_volume or 0)
+                        self.music_player_volume = min(
+                            1.0, max(0.0, self.music_player_volume + step)
                         )
-                        self._reset_ducking_state()
-                        return
+                        _LOGGER.debug(
+                            "Music player volume stepped by %s whilst ducked, "
+                            "restoring to %s instead",
+                            step,
+                            self.music_player_volume,
+                        )
 
                     for i in range(1, 11):
                         volume = min(
                             self.music_player_volume,
                             (current_music_player_volume or 0) + (i * 0.1),
                         )
-                        await self.hass.services.async_call(
-                            "media_player",
-                            "volume_set",
-                            {
-                                "entity_id": self.music_player_entity,
-                                "volume_level": volume,
-                            },
-                            blocking=True,
-                        )
+                        await self._async_set_music_player_volume(volume, blocking=True)
                         if volume == self.music_player_volume:
                             self._reset_ducking_state()
                             break
@@ -321,7 +391,9 @@ class AssistEntityListenerHandler:
     def _reset_ducking_state(self) -> None:
         """Clear ducking state so next duck stores the current volume."""
         self.is_ducked = False
-        self.ducked_volume = None
+        self.ducked_volume = self.ducked_volume_set = None
+        self.set_volume_whilst_ducked = None
+        self.own_volume_call_ids.clear()
         self.music_player_volume = 0.0
 
     async def do_overlay_event(self, state: str) -> None:

--- a/custom_components/view_assist/devices/entity_listeners.py
+++ b/custom_components/view_assist/devices/entity_listeners.py
@@ -53,6 +53,9 @@ from .navigation import NavigationManager
 
 _LOGGER = logging.getLogger(__name__)
 
+# Allows for players rounding volume, whilst below the 0.1 volume_up/down step
+DUCKING_VOLUME_TOLERANCE = 0.02
+
 
 class EntityListeners:
     """Class to manage entity monitors."""
@@ -99,6 +102,7 @@ class AssistEntityListenerHandler:
         self.mic_integration = None
         self.music_player_entity = config.runtime_data.core.musicplayer_device
         self.music_player_volume: float = 0.0
+        self.ducked_volume: float | None = None
         self.is_ducked: bool = False
         self.ducking_task: asyncio.Task | None = None
 
@@ -243,6 +247,7 @@ class AssistEntityListenerHandler:
                         },
                     )
                     self.is_ducked = True
+                    self.ducked_volume = ducking_volume
 
             else:
                 _LOGGER.debug(
@@ -277,6 +282,23 @@ class AssistEntityListenerHandler:
                     current_music_player_volume = music_player_state.attributes.get(
                         "volume_level"
                     )
+
+                    # Volume changed while ducked, so that is now the wanted volume
+                    if (
+                        self.ducked_volume is not None
+                        and current_music_player_volume is not None
+                        and abs(current_music_player_volume - self.ducked_volume)
+                        > DUCKING_VOLUME_TOLERANCE
+                    ):
+                        _LOGGER.debug(
+                            "Music player volume changed to %s while ducked "
+                            "(expected %s), skipping restore",
+                            current_music_player_volume,
+                            self.ducked_volume,
+                        )
+                        self._reset_ducking_state()
+                        return
+
                     for i in range(1, 11):
                         volume = min(
                             self.music_player_volume,
@@ -292,9 +314,15 @@ class AssistEntityListenerHandler:
                             blocking=True,
                         )
                         if volume == self.music_player_volume:
-                            self.is_ducked = False
+                            self._reset_ducking_state()
                             break
                         await asyncio.sleep(0.25)
+
+    def _reset_ducking_state(self) -> None:
+        """Clear ducking state so next duck stores the current volume."""
+        self.is_ducked = False
+        self.ducked_volume = None
+        self.music_player_volume = 0.0
 
     async def do_overlay_event(self, state: str) -> None:
         """Trigger overlay update."""

--- a/custom_components/view_assist/devices/entity_listeners.py
+++ b/custom_components/view_assist/devices/entity_listeners.py
@@ -59,6 +59,9 @@ DUCKING_VOLUME_TOLERANCE = 0.005
 # Time to let the music player report the volume it was actually ducked to
 DUCKING_SETTLE_TIME = 0.5
 
+# Well within what players can act on, whilst keeping float noise out of volumes
+VOLUME_DECIMAL_PLACES = 3
+
 
 class EntityListeners:
     """Class to manage entity monitors."""
@@ -366,9 +369,13 @@ class AssistEntityListenerHandler:
 
                         # Volume was stepped up or down from the ducked level, so
                         # apply that same step to the volume from before ducking
-                        step = current_music_player_volume - (self.ducked_volume or 0)
-                        self.music_player_volume = min(
-                            1.0, max(0.0, self.music_player_volume + step)
+                        step = round(
+                            current_music_player_volume - (self.ducked_volume or 0),
+                            VOLUME_DECIMAL_PLACES,
+                        )
+                        self.music_player_volume = round(
+                            min(1.0, max(0.0, self.music_player_volume + step)),
+                            VOLUME_DECIMAL_PLACES,
                         )
                         _LOGGER.debug(
                             "Music player volume stepped by %s whilst ducked, "
@@ -378,9 +385,12 @@ class AssistEntityListenerHandler:
                         )
 
                     for i in range(1, 11):
-                        volume = min(
-                            self.music_player_volume,
-                            (current_music_player_volume or 0) + (i * 0.1),
+                        volume = round(
+                            min(
+                                self.music_player_volume,
+                                (current_music_player_volume or 0) + (i * 0.1),
+                            ),
+                            VOLUME_DECIMAL_PLACES,
                         )
                         await self._async_set_music_player_volume(volume, blocking=True)
                         if volume == self.music_player_volume:


### PR DESCRIPTION
## In this PR

This affects the case where the integration handles the ducking itself, ie a music player that does not play its audio through the VACA or esphome device.

Two things go wrong if the volume is changed during a conversation.

**An absolute volume is undone.** Asking to set the volume whilst ducked ends with the unducking routine restoring the volume from before ducking, so the command that was just carried out is reverted:

1. mic goes to `listening` - the volume is stored and the player is ducked
2. the intent runs `media_player.volume_set` with the volume asked for
3. mic goes to `idle` - the restore ramps back to the volume stored in step 1

**A relative volume steps from the ducked volume.** `HassSetVolumeRelative` calls `async_volume_up()` / `async_volume_down()` on the entity, so with music at 15% ducked to 4%, "quieter" on a Sonos player (2 point step) leaves the player at 2% rather than the 13% wanted. Note this bypasses the service bus entirely, so the step is not visible as a `call_service` event.

## What this does

At the point of unducking, the volume the player reports is compared with the volume it was ducked to:

| Case | Restored to |
|---|---|
| unchanged | volume from before ducking, as now |
| absolute volume set | left alone, that is the volume wanted |
| stepped up or down | volume from before ducking plus that same step |

Absolute and relative are told apart by watching for `media_player.volume_set` calls on the music player, which the integration's own calls are excluded from by context id. The volume the player reports after ducking is used as the level to compare against, since players round the volume they are set to - a player on whole percent reports 4% after being asked for 4.5%, and without that the step comes out a percent short. Volumes are rounded to 3 decimal places for the same reason: a player that truncates rather than rounds turns 0.13999999999999999 into 13%.

Relates to #200.

The same behaviour was reported for VACA in msp1974/ViewAssist_Companion_App#213 and fixed in apk 0.11.0, but that covers the on device ducking only - with an MA or Sonos media player the integration ducking is used and still restored over the new volume.

## Testing

Tested on HA 2026.7.3 with an LLM conversation agent and a VACA satellite, against both a Music Assistant player (1 point steps, truncates) and a Sonos player (2 point steps, rounds), with debug logging on `custom_components.view_assist.devices.entity_listeners`. Starting from 15%:

| Command | Before | After |
|---|---|---|
| a question, no volume change | 15% | 15% |
| "quieter" (Sonos, 2 points) | 15% | 13% |
| "louder" (Sonos, 2 points) | 15% | 17% |
| "quieter" (MA, 1 point) | 15% | 14% |
| "set the volume to 80%" | 15% | 80% |

## Known limitation

An absolute volume change that does not go through the service bus - someone using the player's own app during the few seconds of ducking - is read as a step and added to the volume from before ducking. There is no way to tell the two apart without the service call.
