### PR TITLE
fix: run display cycle/revert as config entry background tasks

### DIFF
--- a/custom_components/view_assist/devices/navigation.py
+++ b/custom_components/view_assist/devices/navigation.py
@@ -162,8 +162,10 @@ class NavigationManager:
                 else timeout
             )
             _LOGGER.debug("Adding revert to %s in %ss", revert_path, timeout)
-            self.revert_view_task = self.hass.async_create_task(
-                self._display_revert_delay_task(path=revert_path, timeout=timeout)
+            self.revert_view_task = self.config.async_create_background_task(
+                self.hass,
+                self._display_revert_delay_task(path=revert_path, timeout=timeout),
+                f"{self.name} display revert",
             )
 
     def navigate_home(self):
@@ -197,8 +199,10 @@ class NavigationManager:
         if self.cycle_view_task and not self.cycle_view_task.done():
             _LOGGER.debug("Cycle display already running")
             return
-        self.cycle_view_task = self.hass.async_create_task(
-            self._async_display_view_cycle_runner(views)
+        self.cycle_view_task = self.config.async_create_background_task(
+            self.hass,
+            self._async_display_view_cycle_runner(views),
+            f"{self.name} display view cycle",
         )
 
     async def _async_display_view_cycle_runner(self, views: list[str]):


### PR DESCRIPTION
Fixes #234.

### Problem

`start_display_view_cycle()` starts `_async_display_view_cycle_runner()` — an intentionally endless loop — with `hass.async_create_task()`, which creates a **tracked** task. Home Assistant's "wrapping up startup" stage waits for all tracked tasks to complete, so a runner that never returns blocks that stage until bootstrap's 300 s timeout expires:

```
12:18:09  (wrap-up stage begins)
12:23:09  WARNING [homeassistant.bootstrap] Setup timed out for bootstrap waiting on
          {<Task pending name='Task-1363' coro=<NavigationManager._async_display_view_cycle_runner()
          running at custom_components/view_assist/devices/navigation.py:215>} - moving forward
12:23:24  WARNING [homeassistant.core] Something is blocking Home Assistant from wrapping up
          the start up phase. ... The system is waiting for tasks: {<Task ... _async_display_view_cycle_runner ...>}
```

That task is the only entry in the waiting set. It only bites when a device's *default* mode is `cycle`, so the runner is already going while the wrap-up stage executes — which is probably why this didn't reproduce when set manually after startup.

The same task also survives into shutdown:

```
WARNING [homeassistant.core] Task <Task pending ... _async_display_view_cycle_runner ...> was still
running after final writes shutdown stage; Integrations should cancel non-critical tasks when
receiving the stop event to prevent delaying shutdown
```

### Change

Use `ConfigEntry.async_create_background_task()`, which HA does not await at startup and does cancel on entry unload and on shutdown. This matches the pattern already used throughout the integration — `devices/background.py:126`, `devices/menu.py`, `devices/entity_listeners.py`, `core/timers.py`.

`revert_view_task` at `navigation.py:165` is bounded by its own timeout so it can only stall startup by seconds, but it's the same pattern and is changed alongside.

Note this also closes a smaller latent issue: `NavigationManager.async_unload()` is a no-op, and the old tasks weren't bound to the config entry, so reloading a device entry left the previous cycle task running against stale `runtime_data` while the new manager started a second one. Entry-bound background tasks are cancelled on unload.

### Testing

Verified on HA Core 2026.8.0 (HAOS, RPi5) with one device in `cycle` mode:

| | Before | After |
|---|---|---|
| Wrap-up stall | ~5 min 15 s | none |
| `Setup timed out for bootstrap` | present | absent |
| `Something is blocking...` | present | absent |
| Core reaches `RUNNING` | ~5 min 40 s after restart | ≤ 89 s |

Cycling behaviour is unchanged — sampled `sensor.<device>` over a minute post-fix: `/view-assist/clock` → `/view-assist/music` → `/view-assist/weather` → `/view-assist/clock`, at the configured `view_timeout`. No new errors from the integration.

Branched from `dev`.
