### PR TITLE
Add voice satellite integration to config flow

### DIFF
--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -105,29 +105,7 @@ BASE_DEVICE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_NAME): str,
         vol.Required(CONF_MIC_DEVICE): EntitySelector(
-            EntitySelectorConfig(
-                filter=[
-                    EntityFilterSelectorConfig(
-                        integration="esphome", domain=ASSIST_SAT_DOMAIN
-                    ),
-                    EntityFilterSelectorConfig(
-                        integration="hassmic", domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN]
-                    ),
-                    EntityFilterSelectorConfig(
-                        integration="stream_assist",
-                        domain=[SENSOR_DOMAIN, ASSIST_SAT_DOMAIN],
-                    ),
-                    EntityFilterSelectorConfig(
-                        integration="wyoming", domain=ASSIST_SAT_DOMAIN
-                    ),
-                    EntityFilterSelectorConfig(
-                        integration=VACA_DOMAIN, domain=ASSIST_SAT_DOMAIN
-                    ),
-                    EntityFilterSelectorConfig(
-                        integration="voice_satellite", domain=ASSIST_SAT_DOMAIN
-                    ),
-                ]
-            )
+            EntitySelectorConfig(domain=ASSIST_SAT_DOMAIN)
         ),
         vol.Required(CONF_MEDIAPLAYER_DEVICE): EntitySelector(
             EntitySelectorConfig(domain=MEDIAPLAYER_DOMAIN)

--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -123,6 +123,9 @@ BASE_DEVICE_SCHEMA = vol.Schema(
                     EntityFilterSelectorConfig(
                         integration=VACA_DOMAIN, domain=ASSIST_SAT_DOMAIN
                     ),
+                    EntityFilterSelectorConfig(
+                        integration="voice_satellite", domain=ASSIST_SAT_DOMAIN
+                    ),
                 ]
             )
         ),


### PR DESCRIPTION
Support selecting Voice Satellite integration voice satellites in the config flow. These assist_satellite entities are not part of the esphome integration or other integrations filtered in the config flow, they are in jxlarrea's Voice Satellite integration. These are hidden from the View Assist device config flow as a result, preventing using View Assist with these satellites. This PR adds assist_satellite entities from the voice_satellite integration to the filtered list, resolving this issue. Tested on my HA instance successfully.

Alternatively, it may be worthwhile to stop filtering by integrations altogether and support all ASSIST_SAT_DOMAIN domain entities, but that's a larger change that I'll defer to you in case you had good reason to not do so in the first place.