### PR TITLE
Apply display hiding when initial configuration arrives

### DIFF
--- a/custom_components/view_assist/js_modules/view_assist.js
+++ b/custom_components/view_assist/js_modules/view_assist.js
@@ -378,7 +378,7 @@ class ViewAssist {
 
       enabled ? elMain?.style?.setProperty("--mdc-drawer-width", "0px") : elMain?.style?.removeProperty("--mdc-drawer-width");
       //Fix for HA 2026.6 where they changed the sidebar width variable name
-      enabled ? elMain?.style?.setProperty("--ha-sidebar-width", "0px") : elMain?.style?.removeProperty("--ha-sidebar -width");
+      enabled ? elMain?.style?.setProperty("--ha-sidebar-width", "0px") : elMain?.style?.removeProperty("--ha-sidebar-width");
 
       await selectTree(
         elMain, "$ partial-panel-resolver"
@@ -409,7 +409,7 @@ class ViewAssist {
       });
     } catch (e) {
       clearTimeout(this.hide_sidebar_timeout);
-      this.hide_sidebar_timerout = setTimeout(() => {
+      this.hide_sidebar_timeout = setTimeout(() => {
         this.hide_sidebar(enabled);
       }, 200);
     }
@@ -502,29 +502,31 @@ class ViewAssist {
       customElements.define("viewassist-countdown", CountdownTimer)
       customElements.define("viewassist-clock", Clock)
 
-      await this.connect();
-
-      if (this.connected) {
-        window.addEventListener("connection-status", (ev) => {
-          if (ev.detail != "connected") {
-            console.log("View Assist - Connection lost");
-            this.connected = false;
-            this.hide_all_overlays();
-            clearInterval(this.serverTimeHandler)
-          } else {
-            if (!this.connected) {
-              this.connect();
-            }
+      // Register lifecycle handlers before connecting.  The server can send the
+      // initial registered/config event immediately after subscription; that
+      // event navigates to the home view and emits location-changed.  Installing
+      // this handler after connect makes the initial hide pass timing-dependent.
+      window.addEventListener("connection-status", (ev) => {
+        if (ev.detail != "connected") {
+          console.log("View Assist - Connection lost");
+          this.connected = false;
+          this.hide_all_overlays();
+          clearInterval(this.serverTimeHandler)
+        } else {
+          if (!this.connected) {
+            this.connect();
           }
-        });
+        }
+      });
 
-        window.addEventListener("location-changed", () => {
-          setTimeout(() => {
-            this.hide_sections(false);
-            this.display_browser_id();
-          }, 100);
-        });
-      }
+      window.addEventListener("location-changed", () => {
+        setTimeout(() => {
+          this.hide_sections(false);
+          this.display_browser_id();
+        }, 100);
+      });
+
+      await this.connect();
 
     } catch (e) {
       console.log("Error on initialisation: ", e.message);
@@ -665,6 +667,11 @@ class ViewAssist {
 
     // Set variables to payload
     this.variables.config = payload
+
+    // Apply display settings from the config event itself.  This also covers
+    // initial registration if its navigation event happened before the
+    // frontend finished rendering the Lovelace view.
+    setTimeout(() => this.hide_sections(), 100);
 
     if (!payload.mimic_device) {
       // On register, go to default page


### PR DESCRIPTION

### Problem

On slower dashboard clients, the Home Assistant header and sidebar can remain visible after View Assist starts, even though the client is authenticated and already on the configured View Assist home view.

The frontend installs its `location-changed` listener only after `connect()` completes. The initial `registered` configuration can arrive during that connection, navigate to the home view, and emit `location-changed` before the listener exists. The only initial hide pass is therefore timing-dependent.

### Changes

- Register the connection and location lifecycle listeners before connecting.
- Reapply the configured display hiding when each configuration payload is delivered, including initial registration.
- Fix the `hide_sidebar_timerout` typo so retries replace the intended timeout.
- Fix the malformed `--ha-sidebar -width` cleanup property name.

This keeps the existing hiding implementation and event model; it only makes the initial application deterministic and fixes two cleanup/retry typos in the same code path.

### Validation

- `node --check custom_components/view_assist/js_modules/view_assist.js`
- `git diff --check origin/dev...39fe305`
- Deployed commit `39fe305` as a reversible Home Assistant frontend-module canary.
- Verified three physical Android WebView displays (two Echo Show 8 devices and one Echo Show 5) remained authenticated on `/view-assist/baby` for an approximately 24-hour soak.
- At the soak gate, all three showed the View Assist hamburger with no Home Assistant header or sidebar. Each had one foreground VACA activity, one WebView, an active Home Assistant connection, HTTP 200 reachability, and no VACA fatal teardown loop.
- The module served by Home Assistant matched the patched source byte-for-byte (SHA-256 `57aa63695d22cfc98db82c5755a09b7df61a256dd885dfc953e3fc770b500e8e`).
- Bounded device and Home Assistant logs showed no relevant View Assist/frontend initialization errors.

The physical screenshots and secret-safe maintenance summaries are retained locally; they are not attached because the dashboard contains private camera imagery.

### Related work

PR #253 updated the Home Assistant 2026.6 sidebar variable name. This change preserves that behavior and fixes its cleanup spelling while addressing the separate initial-registration race. No overlapping open issue or pull request was found as of 2026-08-27.

### Non-goals

- No backend, navigation, dashboard, authentication, VACA, or network behavior changes.
- No new automatic recovery or polling.
- This finite soak validates the observed startup path on the stated devices; it is not a claim that all client timing combinations are covered.

### Compatibility and rollback

The change uses the existing events, timers, and display-hiding methods and does not change the configuration schema or public API. Rollback is a one-file revert to the previous `view_assist.js`; the pre-change deployed module was retained and verified separately during the canary.

### AI assistance disclosure

AI assistance was used during the investigation, implementation, validation scripting, evidence analysis, and drafting of this report. All reported measurements came from the stated physical test systems. Nicholas Kreucher reviewed the proposed change and final report before submission.
