### PR TITLE
Accept UIX as a card-mod alternative in the missing-modules check

### DIFF
--- a/custom_components/view_assist/js_modules/view_assist.js
+++ b/custom_components/view_assist/js_modules/view_assist.js
@@ -316,7 +316,12 @@ class ViewAssistHelpers {
 
   validateRequirements(requirements) {
     if (typeof requirements === "string") requirements = [requirements];
-    const missing = requirements.filter(req => window.customElements.get(req) === undefined);
+    const missing = requirements.filter(req => {
+      // card-mod is dead upstream on HA 2026.8+; UIX (https://uix.lf.technology/) is a
+      // same-syntax drop-in replacement, so treat its presence as satisfying a card-mod requirement.
+      const isCardModAlternative = req === "card-mod" && !!window.customElements.get("uix-node");
+      return window.customElements.get(req) === undefined && !isCardModAlternative;
+    });
     if (missing.length) {
       return "<div style='display: flex; align-items: center;'><p class='error'>Missing required resources: " + missing.join(", ") + "</p></div>";
     }
@@ -420,7 +425,10 @@ class ViewAssist {
     let missingModules = []
     const modules = ['button-card', 'layout-card', 'card-mod']
     modules.forEach((module) => {
-      if (!customElements.get(module)) {
+      // card-mod is dead upstream on HA 2026.8+; UIX (https://uix.lf.technology/) is a
+      // same-syntax drop-in replacement, so treat its presence as satisfying a card-mod requirement.
+      const isCardModAlternative = module === 'card-mod' && !!customElements.get('uix-node')
+      if (!customElements.get(module) && !isCardModAlternative) {
         missingModules.push(module)
       }
     })


### PR DESCRIPTION
## Summary

- `card-mod` is dead on Home Assistant 2026.8+ ([thomasloven/lovelace-card-mod#606](https://github.com/thomasloven/lovelace-card-mod/issues/606)) — the maintainer has moved on to [UIX](https://uix.lf.technology/), which is a same-syntax drop-in replacement (still reads `card_mod:` config keys directly, no dashboard/theme changes needed).
- UIX never registers a custom element literally named `card-mod`, so the hardcoded `customElements.get('card-mod')` checks in `missingModules()` and `validateRequirements()` (in `js_modules/view_assist.js`) always report card-mod as a missing required resource for UIX users, even though styling continues to work fine.
- This shows up as a red "Missing resources!" banner on the device-registration screen for anyone who has migrated to UIX.
- This PR treats UIX's always-registered `uix-node` custom element as satisfying a `card-mod` requirement, alongside the existing `card-mod` check — so it's non-breaking for people still on real card-mod, and fixes the false positive for UIX users.

## Test plan

- [x] Confirmed on a live instance (HA core-2026.7.4, View Assist 2026.7.0, UIX installed in place of card-mod) that `customElements.get('card-mod')` is `undefined` while `customElements.get('uix-node')` is defined once UIX's frontend module has loaded.
- [x] Verified the patched `missingModules()`/`validateRequirements()` no longer flag `card-mod` as missing under UIX, by checking the equivalent local patch applied directly to the installed integration.
- [ ] Not tested against an instance still running the original `lovelace-card-mod` (should be a no-op there, since `customElements.get('card-mod')` already succeeds and the new `isCardModAlternative` branch is never reached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)