### PR TITLE
Fix timers and allow navigation to use view name

### DIFF
--- a/custom_components/view_assist/core/intent_overrides/hass_cancel_timer.py
+++ b/custom_components/view_assist/core/intent_overrides/hass_cancel_timer.py
@@ -99,10 +99,16 @@ class VACancelTimerIntentHandler(intent.IntentHandler):
         if "time" in slots:
             slot_time = slots["time"]["value"]
             if TimerHelpers.is_datetime_string(slot_time):
-                timer_info = timer_manager.build_timer_info_from_datetime(slot_time)
+                timer_info = TimerHelpers.build_timer_info_from_datetime(
+                    slot_time,
+                    timezone=intent_obj.hass.config.time_zone,
+                    language=intent_obj.language,
+                )
             else:
                 timer_info = await timer_manager.build_timer_info_from_sentence(
-                    slot_time, language=intent_obj.language
+                    slot_time,
+                    timezone=intent_obj.hass.config.time_zone,
+                    language=intent_obj.language,
                 )
             if timer_info:
                 expiry = TimerHelpers.get_expiry_from_timerinfo(timer_info)

--- a/custom_components/view_assist/core/timers/__init__.py
+++ b/custom_components/view_assist/core/timers/__init__.py
@@ -176,6 +176,8 @@ class TimerManager:
     ) -> Timer | None:
         """Build a Timer object from a string, Duration, datetime or TimerInfo."""
 
+        timezone = self._hass.config.time_zone
+
         # Ensure either device_id or entity_id is provided and ensure device_id is set
         if not device_id and entity_id:
             device_id = get_device_id_from_entity_id(self._hass, entity_id)
@@ -194,12 +196,12 @@ class TimerManager:
         elif isinstance(timer_value, Duration):
             _LOGGER.debug("Building %s from Duration: %s", timer_class, timer_value)
             timer_info = TimerHelpers.build_timer_info_from_duration(
-                timer_value, language
+                timer_value, timezone=timezone, language=language
             )
         elif isinstance(timer_value, datetime):
             _LOGGER.debug("Building %s from datetime: %s", timer_class, timer_value)
             timer_info = TimerHelpers.build_timer_info_from_datetime(
-                timer_value, language
+                timer_value, timezone=timezone, language=language
             )
         elif isinstance(timer_value, TimerInfo):
             _LOGGER.debug("Building %s from TimerInfo: %s", timer_class, timer_value)
@@ -298,21 +300,28 @@ class TimerManager:
         return timer
 
     async def build_timer_info_from_sentence(
-        self, sentence: str, source: str | None = None, language: str | None = None
+        self,
+        sentence: str,
+        source: str | None = None,
+        timezone: str = "Europe/London",
+        language: str | None = None,
     ) -> TimerInfo | None:
         """Build a TimerInfo object from a sentence."""
 
         # Sentence could be a datetime
-
-        if language.split("-", 1)[0] != "en" and (
-            translator := Translator.get(self._hass)
+        if (
+            language
+            and language.split("-", 1)[0] != "en"
+            and (translator := Translator.get(self._hass))
         ):
             sentence = await translator.translate_time(sentence, locale=language)
             _LOGGER.debug("Translated time from %s to English: %s", language, sentence)
 
             # if using llm translation, result will be a datetime or duration, so we can use the existing functions to convert to TimerInfo
             if TimerHelpers.is_datetime_string(sentence):
-                return TimerHelpers.build_timer_info_from_datetime(sentence)
+                return TimerHelpers.build_timer_info_from_datetime(
+                    sentence, timezone=timezone, language=language
+                )
 
         # Encode to timer info
         encoder = SentenceEncoder(self._hass, self._config)

--- a/custom_components/view_assist/core/timers/encoder.py
+++ b/custom_components/view_assist/core/timers/encoder.py
@@ -381,7 +381,7 @@ class SentenceEncoder:
                 timer_info.days -= 1
 
         timer_info.is_interval = self._is_interval(timer_info, type_hint)
-        timer_info.tz = dt_util.now().tzinfo.key
+        timer_info.tz = self.hass.config.time_zone
 
         expiry_dt = TimerHelpers.get_expiry_from_timerinfo(timer_info)
         timer_info.expires_at = round(expiry_dt.timestamp())

--- a/custom_components/view_assist/core/timers/helpers.py
+++ b/custom_components/view_assist/core/timers/helpers.py
@@ -73,7 +73,7 @@ class TimerHelpers:
     def is_datetime_string(value: str) -> bool:
         """Check if a string is a datetime string."""
         try:
-            dt_util.parse_datetime(value, raise_on_error=True)
+            dt_util.parse_datetime(str(value), raise_on_error=True)
         except ValueError:
             return False
         return True

--- a/custom_components/view_assist/devices/navigation.py
+++ b/custom_components/view_assist/devices/navigation.py
@@ -236,15 +236,29 @@ class NavigationManager:
         """Handle navigation intents."""
         # Lookup intent in INTENT_TO_VIEW_MAPPING and get config item for view
         # If found, navigate to that view
-        for view, intents in INTENT_TO_VIEW_MAPPING.items():
-            if intent in intents:
-                if path := getattr(self.config.runtime_data.dashboard, view):
-                    dashboard = self.config.runtime_data.dashboard.dashboard
-                    if dashboard and not path.startswith(dashboard):
-                        path = f"{dashboard}/{path}"
-                    if not path.startswith("/"):
-                        path = f"/{path}"
-                    self.browser_navigate(path=path)
+        view_matches = [
+            view
+            for view, intents in INTENT_TO_VIEW_MAPPING.items()
+            if intent in intents
+        ]
+        if not view_matches:
+            _LOGGER.debug("No view mapping found for intent: %s", intent)
+            return
+
+        view = view_matches[0]
+        dashboard = self.config.runtime_data.dashboard.dashboard
+
+        if hasattr(self.config.runtime_data.dashboard, view):
+            path = getattr(self.config.runtime_data.dashboard, view)
+        else:
+            # Navigation will fallback to using view as view name if config item not found
+            path = view
+
+        if dashboard and not path.startswith(dashboard):
+            path = f"{dashboard}/{path}"
+        if not path.startswith("/"):
+            path = f"/{path}"
+        self.browser_navigate(path=path)
 
 
 class NavigationManagerServices:


### PR DESCRIPTION
In this PR

- Fix for timers erroring due to change in function params
- Fix for cancel timers due to change in function location
- Added: navigation will use view as view name from INTENT_TO_VIEW_MAPPING if not found in DashboardConfig