### PR TITLE
added: broadcast intent override

### DIFF
--- a/custom_components/view_assist/core/custom_sentences/en/view_assist_broadcast.yaml
+++ b/custom_components/view_assist/core/custom_sentences/en/view_assist_broadcast.yaml
@@ -1,0 +1,16 @@
+language: "en"
+intents:
+  HassBroadcast:
+    data:
+      - sentences:
+          - "(broadcast|announce) (in|to) [the] {area} [that] {message}"
+          - "(broadcast|announce) [that] {message} (in|to) [the] {area}"
+responses:
+  intents:
+    HassBroadcast:
+      default: >
+        {% set area = slots.area if slots.area is defined else none %}
+        {% set message = slots.message if slots.message is defined else none %}
+        {% set area_text = "to the " ~ area if area is not none else "all areas" %}
+
+        "I have announced {{message}} {{area_text}}."

--- a/custom_components/view_assist/core/intent_overrides/__init__.py
+++ b/custom_components/view_assist/core/intent_overrides/__init__.py
@@ -1,5 +1,6 @@
 """Intent handlers to override core HA handlers."""
 
+from .hass_broadcast import VABroadcastIntentHandler
 from .hass_cancel_timer import (
     VACancelAllTimersIntentHandler,
     VACancelTimerIntentHandler,
@@ -8,10 +9,11 @@ from .hass_media_search_and_play import VAMediaSearchAndPlayHandler
 from .hass_start_timer import VAStartTimerIntentHandler
 from .hass_timer_status import VATimerStatusIntentHandler
 
-all = [
-    VAMediaSearchAndPlayHandler,
-    VAStartTimerIntentHandler,
-    VATimerStatusIntentHandler,
-    VACancelTimerIntentHandler,
-    VACancelAllTimersIntentHandler,
+__all__ = [
+    "VABroadcastIntentHandler",
+    "VACancelAllTimersIntentHandler",
+    "VACancelTimerIntentHandler",
+    "VAMediaSearchAndPlayHandler",
+    "VAStartTimerIntentHandler",
+    "VATimerStatusIntentHandler",
 ]

--- a/custom_components/view_assist/core/intent_overrides/hass_broadcast.py
+++ b/custom_components/view_assist/core/intent_overrides/hass_broadcast.py
@@ -1,0 +1,120 @@
+"""Assist Satellite intents."""
+
+from typing import Final, override
+
+import voluptuous as vol
+
+from homeassistant.components.assist_satellite import (
+    DOMAIN as ASSIST_SATELLITE_DOMAIN,
+    AssistSatelliteEntityFeature,
+)
+from homeassistant.helpers import area_registry as ar, entity_registry as er, intent
+
+EXCLUDED_DOMAINS: Final[set[str]] = {"voip"}
+
+
+class VABroadcastIntentHandler(intent.IntentHandler):
+    """Broadcast a message."""
+
+    intent_type = intent.INTENT_BROADCAST
+    description = """
+        Broadcast a message through the home or in a specified area.
+        Provide the area in the area slot if you want to broadcast to a specific area.
+        If no area is specified, the message will be broadcast to all areas.
+    """
+
+    @property
+    @override
+    def slot_schema(self) -> dict | None:
+        """Return a slot schema."""
+        return {
+            vol.Required("message"): str,
+            vol.Required("area"): str,
+        }
+
+    @override
+    async def async_handle(
+        self, intent_obj: intent.Intent, extra_data: dict | None = None
+    ) -> intent.IntentResponse:
+        """Broadcast a message."""
+        hass = intent_obj.hass
+        ent_reg = er.async_get(hass)
+
+        # Get area_id for area name if provided
+        area_id = None
+        if area_name := intent_obj.slots.get("area", {}).get("value"):
+            area_registry = ar.async_get(hass)
+            area_entry = area_registry.async_get_area_by_name(area_name)
+            if not area_entry:
+                response = intent_obj.create_response()
+                # This needs to be set as an error response so that the conversation agent can handle it as an error
+                response.async_set_speech(
+                    f"Broadcast failed. I could not find the area named {area_name}"
+                )
+                return response
+
+            area_id = area_entry.id
+
+        # Find all assist satellite entities that are not the one invoking the intent
+        entities: dict[str, er.RegistryEntry] = {}
+        for entity in hass.states.async_entity_ids(ASSIST_SATELLITE_DOMAIN):
+            entry = ent_reg.async_get(entity)
+            if (
+                (entry is None)
+                or (
+                    # Area id does not match
+                    area_id and (entry.area_id != area_id)
+                )
+                or (
+                    # Supports announce
+                    not (
+                        entry.supported_features & AssistSatelliteEntityFeature.ANNOUNCE
+                    )
+                )
+                # Not the invoking device
+                or (intent_obj.device_id and (entry.device_id == intent_obj.device_id))
+            ):
+                # Skip satellite
+                continue
+
+            # Check domain of config entry against excluded domains
+            if (
+                entry.config_entry_id
+                and (
+                    config_entry := hass.config_entries.async_get_entry(
+                        entry.config_entry_id
+                    )
+                )
+                and (config_entry.domain in EXCLUDED_DOMAINS)
+            ):
+                continue
+
+            entities[entity] = entry
+
+        await hass.services.async_call(
+            ASSIST_SATELLITE_DOMAIN,
+            "announce",
+            {"message": intent_obj.slots["message"]["value"]},
+            blocking=True,
+            context=intent_obj.context,
+            target={"entity_id": list(entities)},
+        )
+
+        response = intent_obj.create_response()
+        response.async_set_results(
+            success_results=[
+                intent.IntentResponseTarget(
+                    type=intent.IntentResponseTargetType.ENTITY,
+                    id=entity,
+                    name=state.name if (state := hass.states.get(entity)) else entity,
+                )
+                for entity in entities
+            ]
+        )
+        response.async_set_speech_slots(
+            {
+                "area": intent_obj.slots.get("area", {}).get("value"),
+                "message": intent_obj.slots["message"]["value"],
+            }
+        )
+        return response

--- a/custom_components/view_assist/core/intents.py
+++ b/custom_components/view_assist/core/intents.py
@@ -20,7 +20,11 @@ from homeassistant.helpers.intent import (
 )
 from homeassistant.helpers.start import async_at_started
 
-from ..const import DOMAIN, ENABLE_INTENT_HOOKS, INSTALL_CUSTOM_SENTENCES  # noqa: TID252
+from ..const import (  # noqa: TID252
+    DOMAIN,
+    ENABLE_INTENT_HOOKS,
+    INSTALL_CUSTOM_SENTENCES,
+)
 from ..devices.navigation import NavigationManager  # noqa: TID252
 from ..helpers import (  # noqa: TID252
     get_config_entry_by_entity_id,
@@ -29,6 +33,7 @@ from ..helpers import (  # noqa: TID252
 )
 from ..typed import VAConfigEntry  # noqa: TID252
 from .intent_overrides import (
+    VABroadcastIntentHandler,
     VACancelAllTimersIntentHandler,
     VACancelTimerIntentHandler,
     VAMediaSearchAndPlayHandler,
@@ -36,7 +41,10 @@ from .intent_overrides import (
     VATimerStatusIntentHandler,
 )
 
-CUSTOM_SENTENCE_FILES = {"timers": ["view_assist_Timers.yaml"]}
+CUSTOM_SENTENCE_FILES = {
+    "timers": ["view_assist_Timers.yaml"],
+    "broadcast": ["view_assist_broadcast.yaml"],
+}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,6 +86,7 @@ class IntentsManager:
             self.register_override_handler(VATimerStatusIntentHandler())
             self.register_override_handler(VACancelTimerIntentHandler())
             self.register_override_handler(VACancelAllTimersIntentHandler())
+            self.register_override_handler(VABroadcastIntentHandler())
 
             # Hook into intent handlers after Home Assistant has started
             # and hopefully all integrations have registered their intents


### PR DESCRIPTION
In this PR is an intent override for the broadcast intent.

The PR file changes should give clarity of the necessary steps to add such an override.
- view_assist_broadcat.yaml file - add custom sentences with slots and use response slots to build a response sentence output
- hass_broadcast.py - this is the override handler and is basically a copy of the original HA one but added additional items in the description to direct and LLM and also in the main handler to accecpt an area slot being provieded and take a different action if it is.
- intents.py - registering the new override handler and also adding the custom sentence file to the list that will get symlinked into config/custom_sentences/en.  (How we handle these custom files is on the list to do differently but for now...)
- init.py - just part of wiring up the new override handler class

## To explain the handler more
`intent_type` is used to register the handler against this intent.  A constant is used but it could be a string

`description` is used to give direction to the LLM if this is called by it as a tool.  This can take a little trial and error and can need amending when tested against different LLMs.  I need to understand if there is a better phrasing that works for all.  I test with Gemini.

`slot_schema' - defining the inbound slots that can be provided.  Used by LLM.  Custom sentences define the slots to provide into the handler in their structure.  This example has no validation agains tthe slot schema but that can be done to error if the right info is not provided or unknown slots are provided etc

`async_handle` the function called by the intent manager on every intent handler class to define the actions to be taken when the intent is called.

`response = intent_obj.create_response()` this is creating the output back to either the sentence intent manager or the LLM (depending who called the handler).  You can see how you provide any slots you want and then you can also see how that is then used in the response int he custom sentence file.


NOTE: I have not put anything in this PR that allows you to capture this intent handler being called and use the info for display.  I wanted to keep this fairly clean so that you could understand it.  I will send another PR for that functionality that can then be leveraged across all intent handlers (original and override).

Feel free to ask questions...